### PR TITLE
Lift architecture detection

### DIFF
--- a/build/log-architecture.jam
+++ b/build/log-architecture.jam
@@ -20,7 +20,7 @@ feature.feature log-address-model : : free ;
 feature.feature log-instruction-set : : free ;
 
 project.push-current [ project.current ] ;
-project.load [ path.join [ path.make $(here:D) ] ../../context/config ] ;
+project.load [ path.join [ path.make $(here:D) ] ../../config/checks/architecture ] ;
 project.pop-current ;
 
 rule deduce-address-model ( properties * )


### PR DESCRIPTION
Part of a patch set from @vprus for fixing https://svn.boost.org/trac/boost/ticket/10858
Adapt to the movement of the architecture detection logic to Boost.Config