### PR TITLE
Fixed missing symbols in libboost_log_setup (on mac/clang)

### DIFF
--- a/include/boost/log/detail/setup_config.hpp
+++ b/include/boost/log/detail/setup_config.hpp
@@ -30,11 +30,17 @@
 #        define BOOST_LOG_SETUP_DLL
 #   endif
 
-#   if defined(BOOST_HAS_DECLSPEC) && defined(BOOST_LOG_SETUP_DLL)
-#       define BOOST_LOG_SETUP_API __declspec(dllimport)
-#   else
+#   if defined(BOOST_LOG_SETUP_DLL)
+#       if defined(BOOST_SYMBOL_IMPORT)
+#           define BOOST_LOG_SETUP_API BOOST_SYMBOL_IMPORT
+#       elif defined(BOOST_HAS_DECLSPEC)
+#           define BOOST_LOG_SETUP_API __declspec(dllimport)
+#       endif
+#   endif
+#   ifndef BOOST_LOG_SETUP_API
 #       define BOOST_LOG_SETUP_API
-#   endif // defined(BOOST_HAS_DECLSPEC)
+#   endif
+
 //
 // Automatically link to the correct build variant where possible.
 //
@@ -48,12 +54,15 @@
 
 #else // !defined(BOOST_LOG_SETUP_BUILDING_THE_LIB)
 
-#   if defined(BOOST_HAS_DECLSPEC) && defined(BOOST_LOG_SETUP_DLL)
-#       define BOOST_LOG_SETUP_API __declspec(dllexport)
-#   elif defined(__GNUC__) && __GNUC__ >= 4 && (defined(linux) || defined(__linux) || defined(__linux__))
-#       define BOOST_LOG_SETUP_API __attribute__((visibility("default")))
-#   else
-#       define BOOST_LOG_SETUP_API
+#   if defined(BOOST_LOG_SETUP_DLL)
+#       if defined(BOOST_SYMBOL_EXPORT)
+#           define BOOST_LOG_SETUP_API BOOST_SYMBOL_EXPORT
+#       elif defined(BOOST_HAS_DECLSPEC)
+#           define BOOST_LOG_SETUP_API __declspec(dllexport)
+#       endif
+#   endif
+#   ifndef BOOST_LOG_SETUP_API
+#       define BOOST_LOG_SETUP_API BOOST_SYMBOL_VISIBLE
 #   endif
 
 #endif // !defined(BOOST_LOG_SETUP_BUILDING_THE_LIB)


### PR DESCRIPTION
Symbols are not getting properly exported from boost_log_setup when build on Clang on Mac.

Switched the macro to use BOOST_SYMBOL_EXPORT, as is done for the boost_log library symbols.

Tested on Mac OSX 10.10, XCode 6.4, Clang version:
Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.4.0
Thread model: posix