### PR TITLE
Simply test against CLOCK_REALTIME.

### DIFF
--- a/src/timestamp.cpp
+++ b/src/timestamp.cpp
@@ -202,8 +202,7 @@ BOOST_LOG_API get_tick_count_t get_tick_count = &get_tick_count_init;
 
 #endif // _WIN32_WINNT >= 0x0600
 
-#elif (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0)  /* POSIX timers supported */ \
-      || defined(__GNU__) || defined(__OpenBSD__)  /* GNU Hurd and OpenBSD don't support POSIX timers fully but do provide clock_gettime() */
+#elif defined(CLOCK_REALTIME)
 
 BOOST_LOG_API int64_t duration::milliseconds() const
 {


### PR DESCRIPTION
Just like GNU Hurd and OpenBSD, Nuxi CloudABI[1] implements
clock_gettime(), but cannot define _POSIX_TIMERS. The reason for this is
that CloudABI cannot implement the timer_*() interface, as it does not
provide full UNIX signal handling support.

Instead of making the checks in this source file even more complex,
simply fall back to testing against CLOCK_REALTIME. I'd say it would be
very unlikely for an implementation to provide CLOCK_REALTIME, but not
offer a working clock_gettime() function that can operate on it.

[1] Nuxi CloudABI: https://github.com/NuxiNL/cloudlibc