### PR TITLE
Enable the use of clock_gettime() on Nuxi CloudABI.

### DIFF
--- a/src/timestamp.cpp
+++ b/src/timestamp.cpp
@@ -203,7 +203,7 @@ BOOST_LOG_API get_tick_count_t get_tick_count = &get_tick_count_init;
 #endif // _WIN32_WINNT >= 0x0600
 
 #elif (defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0)  /* POSIX timers supported */ \
-      || defined(__GNU__) || defined(__OpenBSD__)  /* GNU Hurd and OpenBSD don't support POSIX timers fully but do provide clock_gettime() */
+      || defined(__GNU__) || defined(__OpenBSD__) || defined(__CloudABI__)  /* GNU Hurd, OpenBSD and Nuxi CloudABI don't support POSIX timers fully but do provide clock_gettime() */
 
 BOOST_LOG_API int64_t duration::milliseconds() const
 {


### PR DESCRIPTION
Just like OpenBSD and HURD, CloudABI provides a clock_gettime() function
without implementing timer_*(). It therefore cannot set _POSIX_TIMERS.