### PR TITLE
Add text_ipc_message_queue_backend

### DIFF
--- a/doc/sink_backends.qbk
+++ b/doc/sink_backends.qbk
@@ -160,6 +160,26 @@ If using formatters is not appropriate for some reason, you can provide your own
 
 [endsect]
 
+[section:text_ipc_message_queue Text IPC message queue backend]
+
+    #include <``[boost_log_sinks_text_ipc_message_queue_backend_hpp]``>
+
+Sometimes, it would be convenient to use a viewer process to monitor the interaction of multiple logger processes on a local machine. To implement this idea, a sink backend that sends logs across processes is needed. The text interprocess communication (IPC) message queue sink backend supports sending formatted log messages to an interprocess message queue, which can then be retrieved and processed by another process. In particular, one may choose to encode a log record with various attribute values into a JSON or XML formatted text message, and then decode the message at the viewer side for processing such as filtering and displaying. As an alternative, one may consider using a network mechanism, e.g., sockets. But doing so would be less efficient and less convenient for this particular purpose.
+
+The backend is implemented by the [class_sinks_basic_text_ipc_message_queue_backend] class template (`text_ipc_message_queue_backend` and `wtext_ipc_message_queue_backend` convenience typedefs provided for narrow and wide character support). It has a supporting message queue implementation that is defined as the member class `message_queue_type`. This member class is intended to be used at the viewer side to extract messages from a message queue. The following two example programs illustrate a logger and a viewer process, respectively. First comes the logger process.
+
+[example_sinks_ipc_logger]
+
+[@boost:/libs/log/example/doc/sinks_ipc_logger.cpp See the complete code].
+
+Here is the viewer process.
+
+[example_sinks_ipc_viewer]
+
+[@boost:/libs/log/example/doc/sinks_ipc_viewer.cpp See the complete code].
+
+[endsect]
+
 [section:syslog Syslog backend]
 
     #include <``[boost_log_sinks_syslog_backend_hpp]``>

--- a/example/doc/sinks_ipc_logger.cpp
+++ b/example/doc/sinks_ipc_logger.cpp
@@ -1,0 +1,69 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include <iostream>
+#include <sstream>
+#include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/thread.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/sources/logger.hpp>
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_ipc_message_queue_backend.hpp>
+
+namespace logging = boost::log;
+namespace src = boost::log::sources;
+namespace sinks = boost::log::sinks;
+namespace keywords = boost::log::keywords;
+
+//[ example_sinks_ipc_logger
+int main()
+{
+    typedef sinks::text_ipc_message_queue_backend backend_t;
+    typedef sinks::synchronous_sink<backend_t> sink_t;
+
+    try
+    {
+        // Create a backend that is associated with the interprocess message queue
+        // named "ipc_message_queue".
+        boost::shared_ptr<backend_t> p_backend(new backend_t(
+            keywords::message_queue_name = "ipc_message_queue",
+            keywords::open_mode = backend_t::open_or_create,
+            keywords::max_queue_size = 5,
+            keywords::max_message_size = 30,
+            keywords::queue_policy = backend_t::drop_when_full,
+            keywords::message_policy = backend_t::truncate_when_too_long));
+        boost::shared_ptr<sink_t> p_sink(new sink_t(p_backend));
+        logging::core::get()->add_sink(p_sink);
+
+        // Try to synthesize an identifier for the logger.
+        src::logger logger;
+        std::ostringstream stream;
+        stream << boost::this_thread::get_id();
+        std::string id = stream.str();
+        id.resize(5, '0');
+        std::cout << "Logger process " << id << " running..." << std::endl;
+
+        // Keep sending numbered messages to the associated message queue until EOF.
+        for (unsigned i = 1; std::cin.get() != std::istream::traits_type::eof(); ++i)
+        {
+            std::cout << "Send message #" << i << " from " << id << '.' << std::endl;
+            BOOST_LOG(logger) << "Message #" << i << " from " << id << '.';
+        }
+    }
+    catch (std::exception const& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cout << "Unknown exception caught." << std::endl;
+    }
+
+    logging::core::get()->remove_all_sinks();
+}
+//]

--- a/example/doc/sinks_ipc_viewer.cpp
+++ b/example/doc/sinks_ipc_viewer.cpp
@@ -1,0 +1,51 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include <iostream>
+#include <string>
+#include <boost/log/sinks/text_ipc_message_queue_backend.hpp>
+
+namespace sinks = boost::log::sinks;
+
+//[ example_sinks_ipc_viewer
+int main()
+{
+    typedef sinks::text_ipc_message_queue_backend::message_queue_type queue_t;
+
+    try
+    {
+        // Create a message_queue_type object that is associated with the interprocess
+        // message queue named "ipc_message_queue".
+        queue_t queue("ipc_message_queue", queue_t::open_or_create, 5, 30);
+        
+        std::cout << "Viewer process running..." << std::endl;
+        
+        char buffer[30] = {};
+        // Keep reading log messages from the associated message queue until EOF.
+        while (std::cin.get() != std::istream::traits_type::eof())
+        {
+            unsigned int message_size = 0;
+            if (queue.try_receive(buffer, 30, message_size))
+            {
+                std::cout << std::string(buffer, buffer + message_size) << std::endl;
+            }
+            else
+            {
+                std::cout << "Message queue is empty. Nothing to receive." << std::endl;
+            }
+        }
+    }
+    catch (std::exception const& e)
+    {
+        std::cout << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cout << "Unknown exception caught." << std::endl;
+    }
+}
+//]

--- a/include/boost/log/keywords/max_message_size.hpp
+++ b/include/boost/log/keywords/max_message_size.hpp
@@ -1,0 +1,40 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   keywords/max_message_size.hpp
+ * \author Lingxi Li
+ * \date   16.10.2015
+ *
+ * The header contains the \c max_message_size keyword declaration.
+ */
+
+#ifndef BOOST_LOG_KEYWORDS_MAX_MESSAGE_SIZE_HPP_INCLUDED_
+#define BOOST_LOG_KEYWORDS_MAX_MESSAGE_SIZE_HPP_INCLUDED_
+
+#include <boost/parameter/keyword.hpp>
+#include <boost/log/detail/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace keywords {
+
+//! The keyword allows to pass the maximum size of a message
+BOOST_PARAMETER_KEYWORD(tag, max_message_size)
+
+} // namespace keywords
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_LOG_KEYWORDS_MAX_MESSAGE_SIZE_HPP_INCLUDED_

--- a/include/boost/log/keywords/max_queue_size.hpp
+++ b/include/boost/log/keywords/max_queue_size.hpp
@@ -1,0 +1,40 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   keywords/max_queue_size.hpp
+ * \author Lingxi Li
+ * \date   16.10.2015
+ *
+ * The header contains the \c max_queue_size keyword declaration.
+ */
+
+#ifndef BOOST_LOG_KEYWORDS_MAX_QUEUE_SIZE_HPP_INCLUDED_
+#define BOOST_LOG_KEYWORDS_MAX_QUEUE_SIZE_HPP_INCLUDED_
+
+#include <boost/parameter/keyword.hpp>
+#include <boost/log/detail/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace keywords {
+
+//! The keyword allows to pass the maximum number of messages a message queue can store
+BOOST_PARAMETER_KEYWORD(tag, max_queue_size)
+
+} // namespace keywords
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_LOG_KEYWORDS_MAX_QUEUE_SIZE_HPP_INCLUDED_

--- a/include/boost/log/keywords/message_policy.hpp
+++ b/include/boost/log/keywords/message_policy.hpp
@@ -1,0 +1,40 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   keywords/message_policy.hpp
+ * \author Lingxi Li
+ * \date   16.10.2015
+ *
+ * The header contains the \c message_policy keyword declaration.
+ */
+
+#ifndef BOOST_LOG_KEYWORDS_MESSAGE_POLICY_HPP_INCLUDED_
+#define BOOST_LOG_KEYWORDS_MESSAGE_POLICY_HPP_INCLUDED_
+
+#include <boost/parameter/keyword.hpp>
+#include <boost/log/detail/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace keywords {
+
+//! The keyword allows to pass the policy for dealing with a message that is too long
+BOOST_PARAMETER_KEYWORD(tag, message_policy)
+
+} // namespace keywords
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_LOG_KEYWORDS_MESSAGE_POLICY_HPP_INCLUDED_

--- a/include/boost/log/keywords/message_queue_name.hpp
+++ b/include/boost/log/keywords/message_queue_name.hpp
@@ -1,0 +1,40 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   keywords/message_queue_name.hpp
+ * \author Lingxi Li
+ * \date   16.10.2015
+ *
+ * The header contains the \c message_queue_name keyword declaration.
+ */
+
+#ifndef BOOST_LOG_KEYWORDS_MESSAGE_QUEUE_NAME_HPP_INCLUDED_
+#define BOOST_LOG_KEYWORDS_MESSAGE_QUEUE_NAME_HPP_INCLUDED_
+
+#include <boost/parameter/keyword.hpp>
+#include <boost/log/detail/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace keywords {
+
+//! The keyword allows to pass the name of a message queue
+BOOST_PARAMETER_KEYWORD(tag, message_queue_name)
+
+} // namespace keywords
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_LOG_KEYWORDS_MESSAGE_QUEUE_NAME_HPP_INCLUDED_

--- a/include/boost/log/keywords/permission.hpp
+++ b/include/boost/log/keywords/permission.hpp
@@ -1,0 +1,40 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   keywords/permission.hpp
+ * \author Lingxi Li
+ * \date   26.10.2015
+ *
+ * The header contains the \c permission keyword declaration.
+ */
+
+#ifndef BOOST_LOG_KEYWORDS_PERMISSION_HPP_INCLUDED_
+#define BOOST_LOG_KEYWORDS_PERMISSION_HPP_INCLUDED_
+
+#include <boost/parameter/keyword.hpp>
+#include <boost/log/detail/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace keywords {
+
+//! The keyword allows to pass access permissions
+BOOST_PARAMETER_KEYWORD(tag, permission)
+
+} // namespace keywords
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_LOG_KEYWORDS_PERMISSION_HPP_INCLUDED_

--- a/include/boost/log/keywords/queue_policy.hpp
+++ b/include/boost/log/keywords/queue_policy.hpp
@@ -1,0 +1,40 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   keywords/queue_policy.hpp
+ * \author Lingxi Li
+ * \date   16.10.2015
+ *
+ * The header contains the \c queue_policy keyword declaration.
+ */
+
+#ifndef BOOST_LOG_KEYWORDS_QUEUE_POLICY_HPP_INCLUDED_
+#define BOOST_LOG_KEYWORDS_QUEUE_POLICY_HPP_INCLUDED_
+
+#include <boost/parameter/keyword.hpp>
+#include <boost/log/detail/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace keywords {
+
+//! The keyword allows to pass the policy for dealing with a full message queue
+BOOST_PARAMETER_KEYWORD(tag, queue_policy)
+
+} // namespace keywords
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_LOG_KEYWORDS_QUEUE_POLICY_HPP_INCLUDED_

--- a/include/boost/log/sinks.hpp
+++ b/include/boost/log/sinks.hpp
@@ -33,6 +33,7 @@
 
 #include <boost/log/sinks/syslog_backend.hpp>
 #include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/log/sinks/text_ipc_message_queue_backend.hpp>
 #include <boost/log/sinks/text_multifile_backend.hpp>
 #include <boost/log/sinks/text_ostream_backend.hpp>
 #ifdef BOOST_WINDOWS

--- a/include/boost/log/sinks/text_ipc_message_queue_backend.hpp
+++ b/include/boost/log/sinks/text_ipc_message_queue_backend.hpp
@@ -1,0 +1,765 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   text_ipc_message_queue_backend.hpp
+ * \author Lingxi Li
+ * \date   14.10.2015
+ *
+ * The header contains implementation of a text interprocess message queue sink
+ * backend along with implementation of a supporting interprocess message queue.
+ */
+
+#ifndef BOOST_LOG_SINKS_TEXT_IPC_MESSAGE_QUEUE_BACKEND_HPP_INCLUDED_
+#define BOOST_LOG_SINKS_TEXT_IPC_MESSAGE_QUEUE_BACKEND_HPP_INCLUDED_
+
+#include <string>
+#include <boost/move/move.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/log/keywords/message_queue_name.hpp>
+#include <boost/log/keywords/open_mode.hpp>
+#include <boost/log/keywords/max_message_size.hpp>
+#include <boost/log/keywords/max_queue_size.hpp>
+#include <boost/log/keywords/queue_policy.hpp>
+#include <boost/log/keywords/message_policy.hpp>
+#include <boost/log/keywords/permission.hpp>
+#include <boost/log/detail/config.hpp>
+#include <boost/log/detail/parameter_tools.hpp>
+#include <boost/log/sinks/basic_sink_backend.hpp>
+#include <boost/log/sinks/frontend_requirements.hpp>
+#include <boost/log/detail/header.hpp>
+#ifdef BOOST_WINDOWS
+#include <windows.h>
+#else // BOOST_WINDOWS
+#include <sys/stat.h>
+#endif // BOOST_WINDOWS
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace sinks {
+
+/*!
+ * \brief An implementation of a text interprocess message queue sink backend and
+ *        a supporting interprocess message queue.
+ *
+ * The sink backend sends formatted log messages to an interprocess message queue
+ * which can be extracted by a viewer process. Methods of this class are not
+ * thread-safe, unless otherwise specified.
+ */
+template < typename CharT >
+class basic_text_ipc_message_queue_backend :
+    public basic_formatted_sink_backend< CharT, concurrent_feeding >
+{
+    //! Base type
+    typedef basic_formatted_sink_backend< CharT > base_type;
+
+public:
+    //! Character type
+    typedef typename base_type::char_type char_type;
+    //! String type to be used as a message text holder
+    typedef typename base_type::string_type string_type;
+
+    /*!
+     * \brief An implementation of a supporting interprocess message queue used
+     *        by \c basic_text_ipc_message_queue_backend. Methods of this class
+     *        are not thread-safe, unless otherwise specified. 
+     */
+    class message_queue_type
+    {
+    private:
+        //! \cond
+        
+        BOOST_MOVABLE_BUT_NOT_COPYABLE(message_queue_type)
+
+        struct implementation;
+        implementation* m_pImpl;
+
+        //! \endcond
+
+    public:
+        //! Message queue open mode type
+        enum open_mode
+        {
+            //! Creates a new one; fail if exists already
+            create_only,
+            //! Opens an existing one; fail if not exist
+            open_only,
+            //! Creates a new or opens an existing; should never fail
+            open_or_create
+        };
+
+        /*!
+         * \brief Access permission type for \c message_queue_type.
+         *        
+         * On Windows platforms, it represents a \c SECURITY_ATTRIBUTES pointer.
+         * On POSIX platforms, it represents a \c mode_t value.
+         */
+        class permission
+        {
+            //! \cond
+
+            BOOST_COPYABLE_AND_MOVABLE(permission)            
+
+            friend class message_queue_type;
+            friend struct message_queue_type::implementation;
+
+#ifdef BOOST_TEST_MODULE
+        public:
+#endif          
+            struct implementation;
+            implementation* m_pImpl;
+
+            //! \endcond
+
+        public:
+            /*!
+             * Default constructor. The method constructs an object that represents
+             * a null \c SECURITY_ATTRIBUTES pointer on Windows platforms, and a
+             * \c mode_t value \c 0644 on POSIX platforms.
+             */
+            BOOST_LOG_API permission();
+
+            /*!
+             * Constructor. The method constructs an object and initializes it with a
+             * Boost shared \c SECURITY_ATTRIBUTES pointer on Windows platforms, and a
+             * \c mode_t value on POSIX platforms. In the shared pointer case, a custom
+             * deleter is usually required.
+             *
+             * \param native_value A native access permission value used to initialize
+             *                     the object.
+             */
+#ifndef BOOST_LOG_DOXYGEN_PASS
+#ifdef BOOST_WINDOWS
+            BOOST_LOG_API permission(shared_ptr< SECURITY_ATTRIBUTES > p_security_attr);
+#else
+            BOOST_LOG_API permission(mode_t mode);
+#endif
+#else
+            permission(implementation-defined native_permission_value);
+#endif // BOOST_LOG_DOXYGEN_PASS
+
+            /*!
+             * Destructor. On Windows platforms, the method destroys the managed
+             * shared \c SECURITY_ATTRIBUTES pointer.
+             */
+            BOOST_LOG_API ~permission();
+
+            /*!
+             * Copy constructor. The method constructs an object that is a copy of
+             * \c other.
+             *
+             * \param other The object to be copied.
+             */
+            BOOST_LOG_API permission(permission const& other);
+            
+            /*!
+             * Move constructor. The method move-constructs an object from \c other.
+             * After the call, the constructed object becomes \c other, while \c other
+             * is left in default-constructed state.
+             *
+             * \param other The object to be moved.
+             */
+            BOOST_LOG_API permission(BOOST_RV_REF(permission) other);
+            
+            /*!
+             * Copy assignment operator. The method copy-assigns the object from
+             * \c other. After the call, the object is a copy of \c other.
+             *
+             * \param other The object to be copied.
+             *
+             * \return A reference to the assigned object.
+             */
+            BOOST_LOG_API permission& operator =(permission const& other);
+
+            /*!
+             * Move assignment operator. The method move-assigns the object from
+             * \c other. After the call, the object becomes \c other, while \c other
+             * is left in default constructed state.
+             *
+             * \param other The object to be moved.
+             *
+             * \return A reference to the assigned object.
+             */
+            BOOST_LOG_API permission& operator =(BOOST_RV_REF(permission) other);
+
+            /*!
+             * The method swaps the object with \c other.
+             *
+             * \param other The other object to swap with.
+             */
+            BOOST_LOG_API void swap(permission& other);
+
+            //! Swaps the two \c permission objects.
+            friend void swap(permission& a, permission& b)
+            {
+                a.swap(b);
+            }
+        };
+
+    public:
+        /*!
+         * Default constructor. The method constructs an object that is not associated with any
+         * message queue.
+         */
+        BOOST_LOG_API message_queue_type();
+
+        /*!
+         * Constructor. The method is used to construct an object that may be associated with a
+         * message queue. The constructed object will be in running state if a message queue is
+         * successfully associated.
+         *
+         * \param name Name of the message queue to be associated with. A valid name is one that
+         *             can be used as a C++ identifier or is a keyword. If an empty string is
+         *             passed, the constructed object is not associated with any message queue.
+         *             On Windows platforms, the name is used to compose kernel object names, and
+         *             you may need to add the "Global\" prefix to the name in certain cases.
+         * \param mode Open mode. If a new message queue is created, the specified settings, as indicated
+         *             by the remaining parameters, are applied. If an existing message queue is opened,
+         *             the specified settings are ignored. For \c open_or_create, users can query whether
+         *             the message queue is actually opened or created by checking the value of \c errno.
+         *             It would be \c EEXIST when opened, and \c ENOENT when created. The \c errno is set
+         *             to \c 0 before doing any operation. For \c create_only, the operation may fail
+         *             with \c errno \c EEXIST. For \c open_only, the operation may fail with \c errno
+         *             \c ENOENT. For any other error, a <tt>boost::system::system_error</tt> exception
+         *             is thrown.
+         * \param max_queue_size Maximum number of messages the queue can hold.
+         * \param max_message_size Maximum size in bytes of each message allowed by the queue.
+         * \param permission_value Access permission for the associated message queue if it is
+         *                         created by this object. The parameter is ignored otherwise.
+         */
+        BOOST_LOG_API explicit message_queue_type(
+            char const* name, open_mode mode = open_or_create,
+            unsigned int max_queue_size = 10, unsigned int max_message_size = 1000,
+            permission const& permission_value = permission());
+
+        /*!
+         * Destructor. Calls <tt>close()</tt> and the precondition to calling <tt>close()</tt>
+         * applies.
+         */
+        BOOST_LOG_API ~message_queue_type();
+
+        /*!
+         * Move constructor. The method move-constructs an object from \c other. After
+         * the call, the constructed object becomes \c other, while \c other is left in
+         * default constructed state.
+         *
+         * \param other The object to be moved.
+         */
+        BOOST_LOG_API message_queue_type(BOOST_RV_REF(message_queue_type) other);
+
+        /*!
+         * Move assignment operator. If the object is associated with a message queue,
+         * <tt>close()</tt> is first called and the precondition to calling <tt>close()</tt>
+         * applies. After the call, the object becomes \c other while \c other is left
+         * in default constructed state.
+         *
+         * \param other The object to be moved.
+         *
+         * \return A reference to the assigned object.
+         */
+        BOOST_LOG_API message_queue_type& operator =(BOOST_RV_REF(message_queue_type) other);
+
+        /*!
+         * The method swaps the object with \c other.
+         *
+         * \param other The other object to swap with.
+         */
+        BOOST_LOG_API void swap(message_queue_type& other);
+
+        //! Swaps the two \c message_queue_type objects.
+        friend void swap(message_queue_type& a, message_queue_type& b)
+        {
+            a.swap(b);
+        }
+
+        /*!
+         * The method sets the message queue to be associated with the object. If the object is
+         * associated with a message queue, <tt>close()</tt> is first called and the precondition
+         * to calling <tt>close()</tt> applies. After the call, the object will be in running state
+         * if a message queue is successfully associated.
+         *
+         * \param name Name of the message queue to be associated with. A valid name is one
+         *             that can be used as a C++ identifier or is a keyword. Passing an empty
+         *             string is equivalent to calling <tt>close()</tt>. On Windows platforms,
+         *             the name is used to compose kernel object names, and you may need to
+         *             add the "Global\" prefix to the name in certain cases.
+         * \param mode Open mode. If a new message queue is created, the specified settings, as indicated
+         *             by the remaining parameters, are applied. If an existing message queue is opened,
+         *             the specified settings are ignored. For \c open_or_create, users can query whether
+         *             the message queue is actually opened or created by checking the value of \c errno.
+         *             It would be \c EEXIST when opened, and \c ENOENT when created. The \c errno is set
+         *             to \c 0 before doing any operation. For \c create_only, the operation may fail
+         *             with \c errno \c EEXIST. For \c open_only, the operation may fail with \c errno
+         *             \c ENOENT. For any other error, a <tt>boost::system::system_error</tt> exception
+         *             is thrown.
+         * \param max_queue_size Maximum number of messages the queue can hold.
+         * \param max_message_size Maximum size in bytes of each message allowed by the queue.
+         * \param permission_value Access permission for the associated message queue if it is
+         *                         created by this object. The parameter is ignored otherwise.
+         *
+         * \return \c true if the operation is successful, and \c false otherwise.
+         */
+        BOOST_LOG_API bool open(
+            char const* name, open_mode mode = open_or_create,
+            unsigned int max_queue_size = 10, unsigned int max_message_size = 1000,
+            permission const& permission_value = permission());
+
+        /*!
+         * Tests whether the object is associated with any message queue.
+         *
+         * \return \c true if the object is associated with a message queue, and \c false otherwise.
+         */
+        BOOST_LOG_API bool is_open() const;
+
+        /*!
+         * This method empties the associated message queue. Throws <tt>std::logic_error</tt> if there
+         * is no associated message queue. Concurrent calls to this method, <tt>send()</tt>,
+         * <tt>try_send()</tt>, <tt>receive()</tt>, <tt>try_receive()</tt>, and <tt>stop()</tt> are OK.
+         */
+        BOOST_LOG_API void clear();
+
+        /*!
+         * The method returns the name of the associated message queue.
+         *
+         * \return Name of the associated message queue, or an empty string if there
+         *         is no associated message queue.
+         */
+        BOOST_LOG_API std::string name() const;
+
+        /*!
+         * The method returns the maximum number of messages the associated message queue
+         * can hold. Note that the returned value may be different from the corresponding
+         * value passed to the constructor or <tt>open()</tt>, for the message queue may
+         * not be created by this object. Throws <tt>std::logic_error</tt> if the object
+         * is not associated with any message queue.
+         *
+         * \return Maximum number of messages the associated message queue can hold.
+         */
+        BOOST_LOG_API unsigned int max_queue_size() const;
+        
+        /*!
+         * The method returns the maximum size in bytes of each message allowed by the
+         * associated message queue. Note that the returned value may be different from the
+         * corresponding value passed to the constructor or <tt>open()</tt>, for the
+         * message queue may not be created by this object. Throws <tt>std::logic_error</tt>
+         * if the object is not associated with any message queue.
+         *
+         * \return Maximum size in bytes of each message allowed by the associated message
+         *         queue.
+         */
+        BOOST_LOG_API unsigned int max_message_size() const;
+
+        /*!
+         * The method wakes up all threads that are blocking on calls to <tt>send()</tt> or
+         * <tt>receive()</tt>. Those calls would then return \c false with \c errno \c EINTR.
+         * Note that, the method does not block until the woke-up threads have actually
+         * returned from <tt>send()</tt> or <tt>receive()</tt>. Other means is needed to ensure
+         * that calls to <tt>send()</tt> or <tt>receive()</tt> have returned, e.g., joining the
+         * threads that might be blocking on the calls. The method also puts the object in stopped
+         * state. When in stopped state, calls to <tt>send()</tt> or <tt>receive()</tt> will
+         * return immediately with return value \c false and \c errno \c EINTR when they would
+         * otherwise block in running state. If there is no associated message queue, an
+         * <tt>std::logic_error</tt> exception is thrown. Concurrent calls to this method,
+         * <tt>send()</tt>, <tt>try_send()</tt>, <tt>receive()</tt>, <tt>try_receive()</tt>,
+         * and <tt>clear()</tt> are OK.
+         */
+        BOOST_LOG_API void stop();
+
+        /*!
+         * The method puts the object in running state where calls to <tt>send()</tt> or
+         * <tt>receive()</tt> may block. This method is thread-safe.
+         */
+        BOOST_LOG_API void reset();
+
+        /*!
+         * The method disassociates the associated message queue, if any. No other threads
+         * should be using this object before calling this method. The <tt>stop()</tt> method
+         * could be used to have any threads currently blocking on <tt>send()</tt> or
+         * <tt>receive()</tt> return, and prevent further calls to them from blocking. Typically,
+         * before calling this method, you would first call <tt>stop()</tt> and then join all
+         * threads that might be blocking on <tt>send()</tt> or <tt>receive()</tt> to ensure that
+         * they have returned from the calls. The associated message queue is destroyed if the
+         * object represents the last outstanding reference to it.
+         */
+        BOOST_LOG_API void close();
+
+        /*!
+         * The method sends a message to the associated message queue. When the object is in
+         * running state and the queue is full, the method blocks. The blocking is interrupted
+         * when <tt>stop()</tt> is called, in which case the method returns \c false with
+         * \c errno \c EINTR. When the object is in stopped state and the queue is full, the
+         * method does not block but returns immediately with return value \c false and \c errno
+         * \c EINTR. If the object is not associated with any message queue, an <tt>std::logic_error</tt>
+         * exception is thrown. <tt>boost::system::system_error</tt> is thrown for errors resulting
+         * from native operating system calls. It is possible to send an empty message by passing
+         * \c 0 to the parameter \c message_size. Concurrent calls to <tt>send()</tt>, <tt>try_send()</tt>,
+         * <tt>receive()</tt>, <tt>try_receive()</tt>, <tt>stop()</tt>, and <tt>clear()</tt> are OK.
+         *
+         * \param message_data The message data to send. Ignored when \c message_size is \c 0.
+         * \param message_size Size of the message data in bytes. If the size is larger than the
+         *                     maximum size allowed by the associated message queue, an
+         *                     <tt>std::logic_error</tt> exception is thrown.
+         *
+         * \return \c true if the operation is successful, and \c false otherwise.
+         */
+        BOOST_LOG_API bool send(void const* message_data, unsigned int message_size);
+
+        /*!
+         * The method performs an attempt to send a message to the associated message queue.
+         * The method is non-blocking, and always returns immediately. If the object is not
+         * associated with any message queue, an <tt>std::logic_error</tt> exception is thrown.
+         * <tt>boost::system::system_error</tt> is thrown for errors resulting from native
+         * operating system calls. Note that it is possible to send an empty message by passing
+         * \c 0 to the parameter \c message_size. Concurrent calls to <tt>send()</tt>,
+         * <tt>try_send()</tt>, <tt>receive()</tt>, <tt>try_receive()</tt>, <tt>stop()</tt>,
+         * and <tt>clear()</tt> are OK.
+         *
+         * \param message_data The message data to send. Ignored when \c message_size is \c 0.
+         * \param message_size Size of the message data in bytes. If the size is larger than the
+         *                     maximum size allowed by the associated message queue, an
+         *                     <tt>std::logic_error</tt> exception is thrown.
+         *
+         * \return \c true if the message is successfully sent, and \c false otherwise (e.g.,
+         *         when the queue is full).
+         */
+        BOOST_LOG_API bool try_send(void const* message_data, unsigned int message_size);
+
+        /*!
+         * The method takes a message from the associated message queue. When the object is in
+         * running state and the queue is empty, the method blocks. The blocking is interrupted
+         * when <tt>stop()</tt> is called, in which case the method returns \c false with
+         * \c errno \c EINTR. When the object is in stopped state and the queue is empty, the
+         * method does not block but returns immediately with return value \c false and \c errno
+         * \c EINTR. If the object is not associated with any message queue, an <tt>std::logic_error</tt>
+         * exception is thrown. <tt>boost::system::system_error</tt> is thrown for errors resulting
+         * from native operating system calls. Concurrent calls to <tt>send()</tt>, <tt>try_send()</tt>,
+         * <tt>receive()</tt>, <tt>try_receive()</tt>, <tt>stop()</tt>, and <tt>clear()</tt> are OK.
+         *
+         * \param buffer The memory buffer to store the received message.
+         * \param buffer_size The size of the buffer in bytes. This parameter should be no smaller
+         *                    than the maximum message size allowed by the associated message queue.
+         *                    Otherwise, an <tt>std::logic_error</tt> exception is thrown.
+         * \param message_size Receives the size of the received message, in bytes.
+         *
+         * \return \c true if the operation is successful, and \c false otherwise.
+         */
+        BOOST_LOG_API bool receive(void* buffer, unsigned int buffer_size, unsigned int& message_size);
+
+        /*!
+         * The method performs an attempt to take a message from the associated message queue. The
+         * method is non-blocking, and always returns immediately. If the object is not associated
+         * with any message queue, an <tt>std::logic_error</tt> exception is thrown.
+         * <tt>boost::system::system_error</tt> is thrown for errors resulting from native operating
+         * system calls. Concurrent calls to <tt>send()</tt>, <tt>try_send()</tt>, <tt>receive()</tt>,
+         * <tt>try_receive()</tt>, <tt>stop()</tt>, and <tt>clear()</tt> are OK.
+         *
+         * \param buffer The memory buffer to store the received message.
+         * \param buffer_size The size of the buffer in bytes. This parameter should be no smaller
+         *                    than the maximum message size allowed by the associated message queue.
+         *                    Otherwise, an <tt>std::logic_error</tt> exception is thrown.
+         * \param message_size Receives the size of the received message, in bytes.
+         *
+         * \return \c true if a message is successfully received, and \c false otherwise (e.g.,
+         *         when the queue is empty).
+         */
+        BOOST_LOG_API bool try_receive(void* buffer, unsigned int buffer_size, unsigned int& message_size);
+    };
+
+    //! Convenient typedef for <tt>message_queue_type::open_mode</tt>.
+    typedef typename message_queue_type::open_mode open_mode;
+    //! Convenient open mode value imported from \c message_queue_type.
+    BOOST_LOG_API static open_mode const create_only = message_queue_type::create_only;
+    //! Convenient open mode value imported from \c message_queue_type.
+    BOOST_LOG_API static open_mode const open_only = message_queue_type::open_only;
+    //! Convenient open mode value imported from \c message_queue_type.
+    BOOST_LOG_API static open_mode const open_or_create = message_queue_type::open_or_create;
+    //! Convenient typedef for <tt>message_queue_type::permission</tt>.
+    typedef typename message_queue_type::permission permission;
+    
+    //! Queue policy type
+    enum queue_policy_type
+    {
+        //! Drop the message when the queue is full (default)
+        drop_when_full,
+        //! Throw an exception when the queue is full
+        throw_when_full,
+        //! Block the send operation when the queue is full
+        block_when_full
+    };
+    //! Message policy type
+    enum message_policy_type
+    {
+        //! Throw an exception when the message is too long for the queue (default)
+        throw_when_too_long,
+        //! Drop the the message when it is too long for the queue
+        drop_when_too_long,
+        //! Truncate the message when it is too long for the queue
+        truncate_when_too_long
+    };
+    
+private:
+    //! \cond
+
+    struct implementation;
+    implementation* m_pImpl;
+
+    //! \endcond
+
+public:
+    /*!
+     * Default constructor. The method constructs the backend using default values
+     * of all the parameters.
+     */
+    BOOST_LOG_API basic_text_ipc_message_queue_backend();
+
+    /*!
+     * Constructor. The method creates a backend that sends messages to an associated
+     * message queue. After the call, the backend will be in running state if a message
+     * queue is successfully associated.
+     *
+     * The following named parameters are supported:
+     *
+     * \li \c message_queue_name - Specifies the name of the queue. The name is given as a C-style string.
+     *                             A valid name is one that can be used as a C++ identifier or is a keyword.
+     *                             If an empty string is passed, the backend has no associated message queue,
+     *                             and does not send any message. Default is an empty string. On Windows
+     *                             platforms, the name is used to compose kernel object names, and you may
+     *                             need to add the "Global\" prefix to the name in certain cases.
+     * \li \c open_mode - Specifies the open mode which is given as a \c open_mode value. If a new message queue
+     *                    is created, the specified message queue settings are applied. If an existing message queue
+     *                    is opened, the specified settings are ignored. The default is \c open_only. For
+     *                    \c open_or_create, users can query whether the message queue is actually opened or created
+     *                    by checking the value of \c errno. It would be \c EEXIST when opened, and \c ENOENT when
+     *                    created. The \c errno is set to \c 0 before doing any operation. For \c create_only, the
+     *                    operation may fail with \c errno \c EEXIST. For \c open_only, the operation may fail with
+     *                    \c errno \c ENOENT. For any other error, a <tt>boost::system::system_error</tt> exception
+     *                    is thrown.
+     * \li \c max_queue_size - Specifies the maximum number of messages the message queue can hold. The parameter
+     *                          is given as an <tt>unsigned int</tt> value, with the default being \c 10.
+     * \li \c max_message_size - Specifies the maximum size in bytes of each message allowed by the message
+     *                           queue. The parameter is given as an <tt>unsigned int</tt> value, with the default
+     *                           being \c 1000.
+     * \li \c queue_policy - Specifies the policy to use when sending to a full message queue. The parameter is
+     *                       given as a \c queue_policy_type value, with the default being \c drop_when_full.
+     * \li \c message_policy - Specifies the policy to use when the message to send is too long for the associated
+     *                         message queue. The parameter is given as a \c message_policy_type value, with the
+     *                         default being \c throw_when_too_long.
+     * \li \c permission - Specifies access permission for the associated message queue if it is created by this
+     *                     object. The parameter is ignored otherwise. The parameter is of type \c permission with
+     *                     the default being a default-constructed \c permission object.
+     */
+#ifndef BOOST_LOG_DOXYGEN_PASS
+    BOOST_LOG_PARAMETRIZED_CONSTRUCTORS_CALL(basic_text_ipc_message_queue_backend, construct)
+#else
+    template< typename... ArgsT >
+    explicit basic_text_ipc_message_queue_backend(ArgsT... const& args);
+#endif
+
+    /*!
+     * Destructor. Calls <tt>close()</tt> and the precondition to calling
+     * <tt>close()</tt> applies.
+     */
+    BOOST_LOG_API ~basic_text_ipc_message_queue_backend();
+
+    /*!
+     * The method returns a reference to the managed \c message_queue_type object.
+     *
+     * \return A reference to the managed \c message_queue_type object.
+     */
+    BOOST_LOG_API message_queue_type& message_queue();
+
+    /*!
+     * The method returns a const reference to the managed \c message_queue_type object.
+     *
+     * \return A const reference to the managed \c message_queue_type object.
+     */
+    BOOST_LOG_API message_queue_type const& message_queue() const;
+
+    /*!
+     * The method returns the name of the associated message queue.
+     *
+     * \return Name of the associated message queue, or an empty string if there
+     *         is no associated message queue.
+     */
+    BOOST_LOG_API std::string name() const;
+
+    /*!
+     * The method sets the message queue to be associated with the object. If the object is
+     * associated with a message queue, <tt>close()</tt> is first called and the precondition
+     * to calling <tt>close()</tt> applies. After the call, the object will be in running state
+     * if a message queue is successfully associated. If no message queue is associated after
+     * the call, the backend does not send any message.
+     *
+     * \param name Name of the message queue to be associated with. A valid name is one
+     *             that can be used as a C++ identifier or is a keyword. Passing an empty
+     *             string is equivalent to calling <tt>close()</tt>. On Windows platforms,
+     *             the name is used to compose kernel object names, and you may need to
+     *             add the "Global\" prefix to the name in certain cases.
+     * \param mode Open mode. If a new message queue is created, the specified settings, as indicated
+     *             by the remaining parameters, are applied. If an existing message queue is opened,
+     *             the specified settings are ignored. For \c open_or_create, users can query whether
+     *             the message queue is actually opened or created by checking the value of \c errno.
+     *             It would be \c EEXIST when opened, and \c ENOENT when created. The \c errno is set
+     *             to \c 0 before doing any operation. For \c create_only, the operation may fail
+     *             with \c errno \c EEXIST. For \c open_only, the operation may fail with \c errno
+     *             \c ENOENT. For any other error, a <tt>boost::system::system_error</tt> exception
+     *             is thrown.
+     * \param max_queue_size Maximum number of messages the queue can hold.
+     * \param max_message_size Maximum size in bytes of each message allowed by the queue.
+     * \param permission_value Access permission for the associated message queue if it is
+     *                         created by this object. The parameter is ignored otherwise.
+     *
+     * \return \c true if the operation is successful, and \c false otherwise.
+     */
+    BOOST_LOG_API bool open(
+        char const* name, open_mode mode = open_only,
+        unsigned int max_queue_size = 10, unsigned int max_message_size = 1000,
+        permission const& permission_value = permission());
+
+    /*!
+     * Tests whether the object is associated with any message queue. Only when the backend has
+     * an associated message queue, will any message be sent.
+     *
+     * \return \c true if the object is associated with a message queue, and \c false otherwise.
+     */
+    BOOST_LOG_API bool is_open() const;
+
+    /*!
+     * The method returns the maximum number of messages the associated message queue
+     * can hold. Note that the returned value may be different from the corresponding
+     * value passed to the constructor or <tt>open()</tt>, for the message queue may
+     * not be created by this object. Throws <tt>std::logic_error</tt> if the object
+     * is not associated with any message queue.
+     *
+     * \return Maximum number of messages the associated message queue can hold.
+     */
+    BOOST_LOG_API unsigned int max_queue_size() const;
+
+    /*!
+     * The method returns the maximum size in bytes of each message allowed by the
+     * associated message queue. Note that the returned value may be different from the
+     * corresponding value passed to the constructor or <tt>open()</tt>, for the
+     * message queue may not be created by this object. Throws <tt>std::logic_error</tt>
+     * if the object is not associated with any message queue.
+     *
+     * \return Maximum size in bytes of each message allowed by the associated message
+     *         queue.
+     */
+    BOOST_LOG_API unsigned int max_message_size() const;
+
+    /*!
+     * The method wakes up all threads that are blocking on calls to <tt>consume()</tt>.
+     * Those calls would then return, dropping the messages they are trying to send.
+     * Note that, the method does not block until the woke-up threads have actually
+     * returned from <tt>consume()</tt>. Other means is needed to ensure that calls to
+     * <tt>consume()</tt> have returned. The method also puts the object in stopped
+     * state. When in stopped state, calls to <tt>consume()</tt> will return immediately,
+     * dropping the messages they are trying to send, when they would otherwise block in
+     * running state. Concurrent calls to this method and <tt>consume()</tt> are OK.
+     */
+    BOOST_LOG_API void stop();
+
+    /*!
+     * The method puts the object in running state where calls to <tt>consume()</tt>
+     * may block. This method is thread-safe.
+     */
+    BOOST_LOG_API void reset();
+
+    /*!
+     * The method disassociates the associated message queue, if any. No other threads
+     * should be using this object before calling this method. The <tt>stop()</tt> method
+     * could be used to have any threads currently blocking on <tt>consume()</tt> return,
+     * and prevent further calls to <tt>consume()</tt> from blocking. The associated message
+     * queue is destroyed, if the object represents the last outstanding reference to it. 
+     */
+    BOOST_LOG_API void close();
+
+    /*!
+     * The method sets the policy to use when sending to a full message queue.
+     *
+     * \param policy The queue policy to set.
+     */
+    BOOST_LOG_API void set_queue_policy(queue_policy_type policy);
+
+    /*!
+     * The method sets the policy to use when the message to send is too long for
+     * the associated message queue.
+     *
+     * \param policy The message policy to set.
+     */
+    BOOST_LOG_API void set_message_policy(message_policy_type policy);
+
+    /*!
+     * The method queries the current queue policy.
+     *
+     * \return Current queue policy.
+     */
+    BOOST_LOG_API queue_policy_type queue_policy() const;
+
+    /*!
+     * The method queries the current message policy.
+     *
+     * \return Current message policy.
+     */
+    BOOST_LOG_API message_policy_type message_policy() const;
+
+    /*!
+     * The method writes the message to the backend. Concurrent calls to this method
+     * are OK. Therefore, the backend may be used with unlocked frontend. <tt>stop()</tt>
+     * can be used to have a blocked <tt>consume()</tt> call return and prevent future
+     * calls to <tt>consume()</tt> from blocking.
+     */
+    BOOST_LOG_API void consume(record_view const& rec, string_type const& formatted_message);
+
+private:
+#ifndef BOOST_LOG_DOXYGEN_PASS
+    //! Constructor implementation
+    template< typename ArgsT >
+    void construct(ArgsT const& args)
+    {
+        construct(
+            args[keywords::message_queue_name | ""],
+            args[keywords::open_mode          | open_only],
+            args[keywords::max_queue_size     | 10],
+            args[keywords::max_message_size   | 1000],
+            args[keywords::queue_policy       | drop_when_full],
+            args[keywords::message_policy     | throw_when_too_long],
+            args[keywords::permission         | permission()]);
+    }
+    //! Constructor implementation
+    BOOST_LOG_API void construct(
+        char const* message_queue_name,
+        open_mode mode,
+        unsigned int max_queue_size,
+        unsigned int max_message_size,
+        queue_policy_type queue_policy_val,
+        message_policy_type message_policy_val,
+        permission const& permission_value);
+#endif // BOOST_LOG_DOXYGEN_PASS
+};
+
+#ifdef BOOST_LOG_USE_CHAR
+typedef basic_text_ipc_message_queue_backend< char > text_ipc_message_queue_backend;      //!< Convenience typedef for narrow-character logging
+#endif
+#ifdef BOOST_LOG_USE_WCHAR_T
+typedef basic_text_ipc_message_queue_backend< wchar_t > wtext_ipc_message_queue_backend;  //!< Convenience typedef for wide-character logging
+#endif
+
+} // namespace sinks
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#include <boost/log/detail/footer.hpp>
+
+#endif // BOOST_LOG_SINKS_TEXT_IPC_MESSAGE_QUEUE_BACKEND_HPP_INCLUDED_

--- a/src/ipc_message_queue_posix.hpp
+++ b/src/ipc_message_queue_posix.hpp
@@ -1,0 +1,808 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   ipc_message_queue_posix.hpp
+ * \author Lingxi Li
+ * \date   17.11.2015
+ *
+ * \brief  This header is the Boost.Log library implementation, see the library documentation
+ *         at http://www.boost.org/doc/libs/release/libs/log/doc/html/index.html.
+ *
+ * This file provides an IPC message queue implementation on POSIX platforms,
+ * and is for inclusion into text_ipc_message_queue_backend.cpp.
+ */
+
+#ifndef BOOST_LOG_IPC_MESSAGE_QUEUE_POSIX_HPP_INCLUDED_
+#define BOOST_LOG_IPC_MESSAGE_QUEUE_POSIX_HPP_INCLUDED_
+
+#include <cerrno>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <boost/atomic.hpp>
+#include <boost/log/sinks/text_ipc_message_queue_backend.hpp>
+#include "posix_wrapper.hpp"
+#include <boost/log/detail/header.hpp>
+
+#ifndef BOOST_WINDOWS
+
+#include <sched.h>
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace sinks {
+
+namespace {
+
+typedef unsigned char byte;
+
+class mutex_attr_type
+{
+public:
+    mutex_attr_type()
+    {
+        aux::pthread_mutexattr_init(ptr());
+    }
+    ~mutex_attr_type()
+    {
+        if (pthread_mutexattr_destroy(ptr()) != 0)
+        {
+            std::terminate();
+        }
+    }
+    pthread_mutexattr_t* ptr()
+    {
+        return &m_Value;
+    }
+    pthread_mutexattr_t const* ptr() const
+    {
+        return &m_Value;
+    }
+
+private:
+    pthread_mutexattr_t m_Value;
+};
+
+class cond_attr_type
+{
+public:
+    cond_attr_type()
+    {
+        aux::pthread_condattr_init(ptr());
+    }
+    ~cond_attr_type()
+    {
+        if (pthread_condattr_destroy(ptr()) != 0)
+        {
+            std::terminate();
+        }
+    }
+    pthread_condattr_t* ptr()
+    {
+        return &m_Value;
+    }
+    pthread_condattr_t const* ptr() const
+    {
+        return &m_Value;
+    }
+
+private:
+    pthread_condattr_t m_Value;
+};
+
+} // unnamed namespace
+
+////////////////////////////////////////////////////////////////////////////////
+//  Permission implementation
+////////////////////////////////////////////////////////////////////////////////
+//! Permission implementation data
+template < typename CharT >
+struct basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::implementation
+{
+    mode_t m_Mode;
+};
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission()
+  : m_pImpl(new implementation())
+{
+    m_pImpl->m_Mode = 0644;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission(
+  mode_t mode)
+  : m_pImpl(new implementation())
+{
+    m_pImpl->m_Mode = mode;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::~permission()
+{
+    delete m_pImpl;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission(
+  permission const& other)
+  : m_pImpl(new implementation())
+{
+    m_pImpl->m_Mode = other.m_pImpl->m_Mode;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission(
+  BOOST_RV_REF(permission) other)
+  : m_pImpl(new implementation())
+{
+    m_pImpl->m_Mode = 0644;
+    swap(other);
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission&
+basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::operator =(permission const& other)
+{
+    m_pImpl->m_Mode = other.m_pImpl->m_Mode;
+    return *this;
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission&
+basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::operator =(BOOST_RV_REF(permission) other)
+{
+    if (this != &other)
+    {
+        m_pImpl->m_Mode = 0644;
+        swap(other);
+    }
+    return *this;
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::swap(permission& other)
+{
+    std::swap(m_pImpl, other.m_pImpl);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Interprocess message queue implementation
+////////////////////////////////////////////////////////////////////////////////
+//! Message queue implementation data
+template < typename CharT >
+struct basic_text_ipc_message_queue_backend< CharT >::message_queue_type::implementation
+{
+    struct header
+    {
+        atomic_bool     m_Created;
+        unsigned int    m_MaxQueueSize;
+        unsigned int    m_MaxMessageSize;
+        pthread_mutex_t m_Mutex;
+        unsigned int    m_RefCount;
+        pthread_cond_t  m_NonEmptyQueue;
+        pthread_cond_t  m_NonFullQueue;
+        unsigned int    m_QueueSize;
+        unsigned int    m_PutPos;
+        unsigned int    m_GetPos;
+    };
+
+    atomic_bool m_fStop;
+    std::string m_Name;
+    int m_fdSharedMemory;
+    header* m_pHeader;
+
+    static mode_t get_mode(permission const& perm)
+    {
+        return perm.m_pImpl->m_Mode;
+    }
+
+    implementation()
+      : m_fStop(true)
+      , m_fdSharedMemory(-1)
+      , m_pHeader(NULL)
+    {
+    }
+
+    ~implementation()
+    {
+        try
+        {
+            close();
+        }
+        catch (...)
+        {
+            std::terminate();
+        }
+    }
+
+    void clear_queue()
+    {
+        m_pHeader->m_QueueSize = 0;
+        m_pHeader->m_PutPos = 0;
+        m_pHeader->m_GetPos = 0;
+        aux::pthread_cond_broadcast(&m_pHeader->m_NonFullQueue);
+    }
+
+    void stop()
+    {
+        bool locked = false;
+        try
+        {
+            if (!is_open()) throw std::logic_error("IPC message queue not opened");
+            int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+            locked = true;
+            if (err == EOWNERDEAD)
+            {
+                clear_queue();
+                aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+            }
+            m_fStop = true;
+            aux::pthread_cond_broadcast(&m_pHeader->m_NonEmptyQueue);
+            aux::pthread_cond_broadcast(&m_pHeader->m_NonFullQueue);
+            aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+        }
+        catch (...)
+        {
+            if (locked) aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            throw;
+        }
+    }
+
+    void reset()
+    {
+        m_fStop = false;
+    }
+
+    void close()
+    {
+        if (is_open())
+        {
+            unsigned int memory_size = sizeof(header) + 
+                (sizeof(unsigned int) + m_pHeader->m_MaxMessageSize) *
+                m_pHeader->m_MaxQueueSize;
+            bool locked = false;
+            try
+            {
+                int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+                locked = true;
+                if (err == EOWNERDEAD)
+                {
+                    clear_queue();
+                    aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+                }
+                if (--m_pHeader->m_RefCount == 0) aux::shm_unlink(m_Name.c_str());
+                aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+                locked = false;
+                aux::munmap(m_pHeader, memory_size);
+                m_pHeader = NULL;
+                aux::close(m_fdSharedMemory);
+                m_fdSharedMemory = -1;
+                m_Name.clear();
+            }
+            catch (...)
+            {
+                if (locked) aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+                throw;
+            }
+        }
+    }
+
+    void create_message_queue(
+      unsigned int max_queue_size, unsigned int max_message_size,
+      permission const& permission_value)
+    {
+        unsigned int memory_size = sizeof(header) + 
+            (sizeof(unsigned int) + max_message_size) * max_queue_size;
+        bool mutex_inited = false;
+        bool non_empty_queue_inited = false;
+        bool non_full_queue_inited = false;
+        try
+        {
+            m_fdSharedMemory = aux::shm_open(m_Name.c_str(), O_RDWR | O_CREAT | O_EXCL,
+                get_mode(permission_value));
+            // Enter critical section
+            aux::ftruncate(m_fdSharedMemory, memory_size);
+            m_pHeader = aux::typed_mmap< header* >(
+                NULL, memory_size, PROT_READ | PROT_WRITE,
+                MAP_SHARED, m_fdSharedMemory, 0);
+
+            mutex_attr_type mutex_attr;
+            aux::pthread_mutexattr_settype(mutex_attr.ptr(), PTHREAD_MUTEX_NORMAL);
+            aux::pthread_mutexattr_setpshared(mutex_attr.ptr(), PTHREAD_PROCESS_SHARED);
+            aux::pthread_mutexattr_setrobust(mutex_attr.ptr(), PTHREAD_MUTEX_ROBUST);
+            aux::pthread_mutex_init(&m_pHeader->m_Mutex, mutex_attr.ptr());
+            mutex_inited = true;
+
+            cond_attr_type cond_attr;
+            aux::pthread_condattr_setpshared(cond_attr.ptr(), PTHREAD_PROCESS_SHARED);
+            aux::pthread_cond_init(&m_pHeader->m_NonEmptyQueue, cond_attr.ptr());
+            non_empty_queue_inited = true;
+            aux::pthread_cond_init(&m_pHeader->m_NonFullQueue, cond_attr.ptr());
+            non_full_queue_inited = true;
+
+            m_pHeader->m_MaxQueueSize = max_queue_size;
+            m_pHeader->m_MaxMessageSize = max_message_size;
+            m_pHeader->m_RefCount = 1;
+            m_pHeader->m_QueueSize = 0;
+            m_pHeader->m_PutPos = 0;
+            m_pHeader->m_GetPos = 0;
+            m_pHeader->m_Created = true;
+            // Leave section ends
+        }
+        catch (...)
+        {
+            if (mutex_inited) aux::pthread_mutex_destroy(&m_pHeader->m_Mutex);
+            if (non_empty_queue_inited) aux::pthread_cond_destroy(&m_pHeader->m_NonEmptyQueue);
+            if (non_full_queue_inited) aux::pthread_cond_destroy(&m_pHeader->m_NonFullQueue);
+            aux::safe_munmap(m_pHeader, memory_size);
+            if (m_fdSharedMemory >= 0)
+            {
+                aux::shm_unlink(m_Name.c_str());
+                aux::close(m_fdSharedMemory);
+                m_fdSharedMemory = -1;
+            }
+            m_Name.clear();
+            throw;
+        }
+    }
+
+    void open_message_queue(unsigned int max_queue_size, unsigned int max_message_size,
+      permission const& permission_value)
+    {
+        bool locked = false;
+        struct stat status = {};
+        try
+        {
+            m_fdSharedMemory = aux::shm_open(m_Name.c_str(), O_RDWR, get_mode(permission_value));
+            aux::fstat(m_fdSharedMemory, &status);
+            if (!status.st_size) throw aux::make_system_error("shm_open", ENOENT);
+            m_pHeader = aux::typed_mmap< header* >(
+                NULL, status.st_size, PROT_READ | PROT_WRITE,
+                MAP_SHARED, m_fdSharedMemory, 0);
+
+            if (!m_pHeader->m_Created) throw aux::make_system_error("shm_open", ENOENT);
+            int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+            locked = true;
+            if (err == EOWNERDEAD)
+            {   
+                clear_queue();
+                aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+            }
+            if (!m_pHeader->m_RefCount) throw aux::make_system_error("shm_open", ENOENT);
+            ++m_pHeader->m_RefCount;
+            aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+        }
+        catch (...)
+        {
+            if (locked) aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            aux::safe_munmap(m_pHeader, status.st_size);
+            aux::safe_close(m_fdSharedMemory);
+            m_Name.clear();
+            throw;
+        }
+    }
+
+    bool open(char const* name, open_mode mode, unsigned int max_queue_size,
+      unsigned int max_message_size, permission const& permission_value)
+    {
+        close();
+        errno = 0;
+        
+        if (*name)
+        {
+            m_Name = m_Name + "/" + name;
+            try
+            {
+                if (mode == create_only)
+                {
+                    create_message_queue(
+                        max_queue_size, max_message_size, permission_value);
+                    errno = ENOENT;
+                }
+                else // open_only
+                {
+                    open_message_queue(
+                        max_queue_size, max_message_size, permission_value);
+                    errno = EEXIST;
+                }
+            }
+            catch (system::system_error const& sys_err)
+            {
+                switch (sys_err.code().value())
+                {
+                case EEXIST:
+                    errno = EEXIST;
+                    break;
+                case ENOENT:
+                    errno = ENOENT;
+                    break;
+                default:
+                    throw;
+                }
+                return false;
+            }
+            m_fStop = false;
+            return true;
+        }
+        m_fStop = false;
+        return true;
+    }
+
+    bool is_open() const
+    {
+        return m_pHeader;
+    }
+
+    void clear()
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        bool locked = false;
+        try
+        {
+            int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+            locked = true;
+            clear_queue();
+            if (err == EOWNERDEAD) aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+            aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+        }
+        catch (...)
+        {
+            if (locked) aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            throw;
+        }
+    }
+
+    std::string name() const
+    {
+        return m_Name.size() ? m_Name.substr(1) : "";
+    }
+
+    unsigned int max_queue_size() const
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        return m_pHeader->m_MaxQueueSize;
+    }
+
+    unsigned int max_message_size() const
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        return m_pHeader->m_MaxMessageSize;
+    }
+
+    // Mutual exclusion should be guaranteed upon calling this function.
+    void put_message(void const* message_data, unsigned int message_size)
+    {
+        byte* p = reinterpret_cast< byte* >(m_pHeader);
+        p += sizeof(header) + (sizeof(unsigned int) + m_pHeader->m_MaxMessageSize) * m_pHeader->m_PutPos;
+        std::memcpy(p, &message_size, sizeof(unsigned int));
+        p += sizeof(unsigned int);
+        std::memcpy(p, message_data, message_size);
+        m_pHeader->m_PutPos = (m_pHeader->m_PutPos + 1) % m_pHeader->m_MaxQueueSize;
+        ++m_pHeader->m_QueueSize;
+        aux::pthread_cond_signal(&m_pHeader->m_NonEmptyQueue);
+    }
+
+    // Mutual exclusion should be guaranteed upon calling this function.
+    void get_message(void* buffer, unsigned int, unsigned int& message_size)
+    {
+        byte* p = reinterpret_cast< byte* >(m_pHeader);
+        p += sizeof(header) + (sizeof(unsigned int) + m_pHeader->m_MaxMessageSize) * m_pHeader->m_GetPos;
+        std::memcpy(&message_size, p, sizeof(unsigned int));
+        p += sizeof(unsigned int);
+        std::memcpy(buffer, p, message_size);
+        m_pHeader->m_GetPos = (m_pHeader->m_GetPos + 1) % m_pHeader->m_MaxQueueSize;
+        --m_pHeader->m_QueueSize;
+        aux::pthread_cond_signal(&m_pHeader->m_NonFullQueue);
+    }
+
+    bool send(void const* message_data, unsigned int message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (message_size > m_pHeader->m_MaxMessageSize) throw std::logic_error("Message is too long");
+        errno = 0;
+        bool locked = false;
+        
+        try
+        {
+            int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+            locked = true;
+            if (err == EOWNERDEAD)
+            {
+                clear_queue();
+                aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+            }
+            while (m_pHeader->m_QueueSize >= m_pHeader->m_MaxQueueSize && !m_fStop) // full
+            {
+                aux::pthread_cond_wait(&m_pHeader->m_NonFullQueue, &m_pHeader->m_Mutex);
+            }
+            if (m_pHeader->m_QueueSize >= m_pHeader->m_MaxQueueSize)
+            {
+                aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+                errno = EINTR;
+                return false;
+            }
+            put_message(message_data, message_size);
+            aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            return true;
+        }
+        catch (...)
+        {
+            // The non-`aux::` version is used here for the suspicion that `aux::pthread_cond_wait()`
+            // may throw with `m_Mutex` unlocked. `locked` is still set in this case, and we
+            // end up with unlocking a mutex that is not locked at all. With the non-`aux::`
+            // version, the unlock operation simply fails without throwing any exception, and
+            // no harmful effects will ever happen.
+            if (locked) pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            throw;
+        }
+    }
+    
+    bool try_send(void const* message_data, unsigned int message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (message_size > m_pHeader->m_MaxMessageSize) throw std::logic_error("Message is too long");
+        bool locked = false;
+        try
+        {
+            int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+            locked = true;
+            if (err == EOWNERDEAD)
+            {
+                clear_queue();
+                aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+            }
+            if (m_pHeader->m_QueueSize >= m_pHeader->m_MaxQueueSize)
+            {
+                aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+                return false;
+            }
+            put_message(message_data, message_size);
+            aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            return true;
+        }
+        catch (...)
+        {
+            if (locked) aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            throw;
+        }
+    }
+
+    bool receive(void* buffer, unsigned int buffer_size, unsigned int& message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (buffer_size < m_pHeader->m_MaxMessageSize) throw std::logic_error("Insufficient buffer");
+        errno = 0;
+        bool locked = false;
+        
+        try
+        {
+            int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+            locked = true;
+            if (err == EOWNERDEAD)
+            {
+                clear_queue();
+                aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+            }
+            while (!m_pHeader->m_QueueSize && !m_fStop)
+            {
+                aux::pthread_cond_wait(&m_pHeader->m_NonEmptyQueue, &m_pHeader->m_Mutex);
+            }
+            if (!m_pHeader->m_QueueSize)
+            {
+                aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+                errno = EINTR;
+                return false;
+            }
+            get_message(buffer, buffer_size, message_size);
+            aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            return true;
+        }
+        catch (...)
+        {
+            // The non-`aux::` version is used here for the suspicion that `aux::pthread_cond_wait()`
+            // may throw with `m_Mutex` unlocked. `locked` is still set in this case, and we
+            // end up with unlocking a mutex that is not locked at all. With the non-`aux::`
+            // version, the unlock operation simply fails without throwing any exception, and
+            // no harmful effects will ever happen.
+            if (locked) pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            throw;
+        }
+    }
+
+    bool try_receive(void* buffer, unsigned int buffer_size, unsigned int& message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (buffer_size < m_pHeader->m_MaxMessageSize) throw std::logic_error("Insufficient buffer");
+        bool locked = false;
+        try
+        {
+            int err = aux::pthread_mutex_lock(&m_pHeader->m_Mutex);
+            locked = true;
+            if (err == EOWNERDEAD)
+            {
+                clear_queue();
+                aux::pthread_mutex_consistent(&m_pHeader->m_Mutex);
+            }
+            if (!m_pHeader->m_QueueSize)
+            {
+                aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+                return false;
+            }
+            get_message(buffer, buffer_size, message_size);
+            aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            return true;
+        }
+        catch (...)
+        {
+            if (locked) aux::pthread_mutex_unlock(&m_pHeader->m_Mutex);
+            throw;
+        }
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//  message_queue_type implementation
+////////////////////////////////////////////////////////////////////////////////
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::message_queue_type()
+  : m_pImpl(new implementation())
+{
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::message_queue_type(
+  char const* name, open_mode mode, unsigned int max_queue_size, unsigned int max_message_size,
+  permission const& permission_value)
+  : m_pImpl(new implementation())
+{
+    open(name, mode, max_queue_size, max_message_size, permission_value);
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::~message_queue_type()
+{
+    delete m_pImpl;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::message_queue_type(
+  BOOST_RV_REF(message_queue_type) other)
+  : m_pImpl(new implementation())
+{
+    swap(other);
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type&
+basic_text_ipc_message_queue_backend< CharT >::message_queue_type::operator =(
+  BOOST_RV_REF(message_queue_type) other)
+{
+    if (this != &other)
+    {
+        close();
+        swap(other);
+    }
+    return *this;
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::swap(
+  message_queue_type& other)
+{
+    std::swap(m_pImpl, other.m_pImpl);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::open(
+  char const* name, open_mode mode, unsigned int max_queue_size, unsigned int max_message_size,
+  permission const& permission_value)
+{
+    if (mode != open_or_create)
+    {
+        return m_pImpl->open(name, mode, max_queue_size, max_message_size, permission_value);
+    }
+    else
+    {
+        while (true)
+        {
+            if (m_pImpl->open(name, create_only, max_queue_size, max_message_size, permission_value)) return true;
+            if (m_pImpl->open(name, open_only, max_queue_size, max_message_size, permission_value)) return true;
+            sched_yield();
+        }
+    }
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::is_open() const
+{
+    return m_pImpl->is_open();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::clear()
+{
+    m_pImpl->clear();
+}
+
+template < typename CharT >
+BOOST_LOG_API std::string basic_text_ipc_message_queue_backend< CharT >::message_queue_type::name() const
+{
+    return m_pImpl->name();
+}
+
+template < typename CharT >
+BOOST_LOG_API unsigned int basic_text_ipc_message_queue_backend< CharT >::message_queue_type::max_queue_size() const
+{
+    return m_pImpl->max_queue_size();
+}
+
+template < typename CharT >
+BOOST_LOG_API unsigned int basic_text_ipc_message_queue_backend< CharT >::message_queue_type::max_message_size() const
+{
+    return m_pImpl->max_message_size();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::stop()
+{
+    m_pImpl->stop();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::reset()
+{
+    m_pImpl->reset();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::close()
+{
+    m_pImpl->close();
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::send(
+  void const* message_data, unsigned int message_size)
+{
+    return m_pImpl->send(message_data, message_size);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::try_send(
+  void const* message_data, unsigned int message_size)
+{
+    return m_pImpl->try_send(message_data, message_size);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::receive(
+  void* buffer, unsigned int buffer_size, unsigned int& message_size)
+{
+    return m_pImpl->receive(buffer, buffer_size, message_size);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::try_receive(
+  void* buffer, unsigned int buffer_size, unsigned int& message_size)
+{
+    return m_pImpl->try_receive(buffer, buffer_size, message_size);
+}
+
+} // namespace sinks
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_WINDOWS
+
+#include <boost/log/detail/footer.hpp>
+
+#endif // BOOST_LOG_IPC_MESSAGE_QUEUE_POSIX_HPP_INCLUDED_

--- a/src/ipc_message_queue_win.hpp
+++ b/src/ipc_message_queue_win.hpp
@@ -1,0 +1,638 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   ipc_message_queue_win.hpp
+ * \author Lingxi Li
+ * \date   28.10.2015
+ *
+ * \brief  This header is the Boost.Log library implementation, see the library documentation
+ *         at http://www.boost.org/doc/libs/release/libs/log/doc/html/index.html.
+ *
+ * This file provides an IPC message queue implementation on Windows platforms,
+ * and is for inclusion into text_ipc_message_queue_backend.cpp.
+ */
+
+#ifndef BOOST_LOG_IPC_MESSAGE_QUEUE_WIN_HPP_INCLUDED_
+#define BOOST_LOG_IPC_MESSAGE_QUEUE_WIN_HPP_INCLUDED_
+
+#include <cerrno>
+#include <cstddef>
+#include <cstring>
+#include <algorithm>
+#include <exception>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <boost/log/sinks/text_ipc_message_queue_backend.hpp>
+#include "win_wrapper.hpp"
+#include <boost/log/detail/header.hpp>
+
+#if defined(BOOST_WINDOWS)
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace sinks {
+
+namespace {
+
+typedef unsigned char byte;
+
+class mutex_type
+{
+public:
+    explicit mutex_type(HANDLE mutex)
+      : m_hMutex(mutex)
+      , m_fLocked(false)
+    {
+    }
+
+    DWORD lock()
+    {
+        if (m_fLocked) throw std::logic_error("Mutex already locked");
+        DWORD wait_result = aux::wait_for_single_object(m_hMutex, INFINITE);
+        m_fLocked = true;
+        return wait_result;
+    }
+
+    void unlock()
+    {
+        if (!m_fLocked) throw std::logic_error("Mutex not locked");
+        aux::release_mutex(m_hMutex);
+        m_fLocked = false;
+    }
+
+    ~mutex_type()
+    {
+        if (m_fLocked) unlock();
+    }
+
+private:
+    HANDLE m_hMutex;
+    bool m_fLocked;
+};
+
+} // unnamed namespace
+
+////////////////////////////////////////////////////////////////////////////////
+//  Permission implementation
+////////////////////////////////////////////////////////////////////////////////
+//! Permission implementation data
+template < typename CharT >
+struct basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::implementation
+{
+    shared_ptr< SECURITY_ATTRIBUTES > m_pSecurityAttr;
+};
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission()
+  : m_pImpl(new implementation())
+{
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission(
+  shared_ptr< SECURITY_ATTRIBUTES > p_security_attr)
+  : m_pImpl(new implementation())
+{
+    m_pImpl->m_pSecurityAttr = p_security_attr;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::~permission()
+{
+    delete m_pImpl;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission(
+  permission const& other)
+  : m_pImpl(new implementation())
+{
+    m_pImpl->m_pSecurityAttr = other.m_pImpl->m_pSecurityAttr;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::permission(
+  BOOST_RV_REF(permission) other)
+  : m_pImpl(new implementation())
+{
+    swap(other);
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission&
+basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::operator =(permission const& other)
+{
+    m_pImpl->m_pSecurityAttr = other.m_pImpl->m_pSecurityAttr;
+    return *this;
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission&
+basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::operator =(BOOST_RV_REF(permission) other)
+{
+    if (this != &other)
+    {
+        m_pImpl->m_pSecurityAttr.reset();
+        swap(other);
+    }
+    return *this;
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::swap(permission& other)
+{
+    std::swap(m_pImpl, other.m_pImpl);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Interprocess message queue implementation
+////////////////////////////////////////////////////////////////////////////////
+//! Message queue implementation data
+template < typename CharT >
+struct basic_text_ipc_message_queue_backend< CharT >::message_queue_type::implementation
+{
+    struct header
+    {
+        unsigned int m_MaxQueueSize;
+        unsigned int m_MaxMessageSize;
+        unsigned int m_QueueSize;
+        unsigned int m_PutPos;
+        unsigned int m_GetPos;
+    };
+
+    HANDLE  m_hStopEvent;
+    std::string m_Name;
+    HANDLE  m_hMutex;
+    HANDLE  m_hFileMapping;
+    header* m_pHeader;
+    HANDLE  m_hNonEmptyQueueEvent;
+    HANDLE  m_hNonFullQueueEvent;
+
+    static SECURITY_ATTRIBUTES* get_psa(permission const& perm)
+    {
+        return perm.m_pImpl->m_pSecurityAttr.get();
+    }
+
+    void clear_queue()
+    {
+        m_pHeader->m_QueueSize = 0;
+        m_pHeader->m_PutPos = 0;
+        m_pHeader->m_GetPos = 0;
+        aux::set_event(m_hNonFullQueueEvent);
+    }
+
+    implementation()
+      : m_hStopEvent(aux::create_event(NULL, TRUE, TRUE, NULL))
+      , m_hMutex(0)
+      , m_hFileMapping(0)
+      , m_pHeader(NULL)
+      , m_hNonEmptyQueueEvent(0)
+      , m_hNonFullQueueEvent(0)
+    {
+    }
+
+    ~implementation()
+    {
+        try
+        {
+            if (is_open()) close();
+            aux::close_handle(m_hStopEvent);
+        }
+        catch (...)
+        {
+            std::terminate();
+        }
+    }
+
+    void stop()
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        aux::set_event(m_hStopEvent);
+    }
+
+    void reset()
+    {
+        aux::reset_event(m_hStopEvent);
+    }
+
+    void close()
+    {
+        aux::safe_close_handle(m_hNonFullQueueEvent);
+        aux::safe_close_handle(m_hNonEmptyQueueEvent);
+        aux::safe_unmap_view_of_file(m_pHeader);
+        aux::safe_close_handle(m_hFileMapping);
+        aux::safe_close_handle(m_hMutex);
+        m_Name.clear();
+    }
+
+    bool open(char const* name, open_mode mode, unsigned int max_queue_size,
+      unsigned int max_message_size, permission const& permission_value)
+    {
+        if (is_open()) close();
+
+        system::system_error sys_err(0, system::system_category());
+        errno = 0;
+
+        m_Name = name;
+        if (*name)
+        {
+            unsigned int memory_size = sizeof(header) + 
+                (sizeof(unsigned int) + max_message_size) * max_queue_size;
+
+            static char const uuid[] = "37394D1EBAC14602BC9492CB1971F756";
+            std::string mutex_name = m_Name + uuid + "Mutex";
+            std::string non_empty_event_name = m_Name + uuid + "NonEmptyQueueEvent";
+            std::string non_full_event_name = m_Name + uuid + "NonFullQueueEvent";
+
+            try
+            {
+                if (mode == open_or_create)
+                {
+                    SetLastError(ERROR_SUCCESS);
+                    m_hMutex = aux::create_mutex(get_psa(permission_value), FALSE, mutex_name.c_str());
+                    mode = GetLastError() == ERROR_ALREADY_EXISTS ? open_only : create_only;
+                }
+                
+                if (mode == create_only)
+                {
+                    if (!m_hMutex)
+                    {
+                        SetLastError(ERROR_SUCCESS);
+                        m_hMutex = aux::create_mutex(get_psa(permission_value), FALSE, mutex_name.c_str());
+                        if (GetLastError() == ERROR_ALREADY_EXISTS)
+                        {
+                            throw aux::make_win_system_error("CreateMutex");
+                        }
+                    }
+
+                    // Mutual exclusion begins.
+                    m_hFileMapping = aux::create_file_mapping(INVALID_HANDLE_VALUE,
+                        get_psa(permission_value), PAGE_READWRITE, 0, memory_size, name);
+                    void* p_memory = aux::map_view_of_file(m_hFileMapping, FILE_MAP_WRITE, 0, 0, 0);
+                    m_pHeader = static_cast< header* >(p_memory);
+
+                    m_pHeader->m_MaxQueueSize = max_queue_size;
+                    m_pHeader->m_MaxMessageSize = max_message_size;
+                    m_pHeader->m_QueueSize = 0;
+                    m_pHeader->m_PutPos = 0;
+                    m_pHeader->m_GetPos = 0;
+
+                    m_hNonEmptyQueueEvent = aux::create_event(get_psa(permission_value),
+                        TRUE, TRUE, non_empty_event_name.c_str());
+                    m_hNonFullQueueEvent = aux::create_event(get_psa(permission_value),
+                        TRUE, TRUE, non_full_event_name.c_str());
+                    // Mutual exclusion ends.
+
+                    errno = ENOENT;
+                }
+                else // mode == open_only
+                {
+                    if (!m_hMutex)
+                    {
+                        m_hMutex = aux::open_mutex(SYNCHRONIZE, FALSE, mutex_name.c_str());
+                    }
+
+                    m_hFileMapping = aux::open_file_mapping(FILE_MAP_WRITE, FALSE, name);
+                    void* p_memory = aux::map_view_of_file(m_hFileMapping, FILE_MAP_WRITE, 0, 0, 0);
+                    m_pHeader = static_cast< header* >(p_memory);
+
+                    m_hNonEmptyQueueEvent = aux::open_event(SYNCHRONIZE | EVENT_MODIFY_STATE,
+                        FALSE, non_empty_event_name.c_str());
+                    m_hNonFullQueueEvent = aux::open_event(SYNCHRONIZE | EVENT_MODIFY_STATE,
+                        FALSE, non_full_event_name.c_str());
+
+                    errno = EEXIST;
+                }
+            }
+            catch (system::system_error const& except)
+            {
+                sys_err = except;
+            }
+            catch (...)
+            {
+                sys_err = system::system_error(ERROR_FUNCTION_FAILED, system::system_category(),
+                    "message_queue_type::open");
+            }
+        }
+
+        if (sys_err.code())
+        {
+            close();
+            errno = sys_err.code().value() == ERROR_FILE_NOT_FOUND ? ENOENT :
+                    sys_err.code().value() == ERROR_ALREADY_EXISTS ? EEXIST : 0;
+            if (!errno) throw sys_err;
+            return false;
+        }
+        else
+        {
+            reset();
+            return true;
+        }
+    }
+
+    bool is_open() const
+    {
+        return m_pHeader;
+    }
+
+    void clear()
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        mutex_type locker(m_hMutex);
+        locker.lock();
+        clear_queue();
+    }
+
+    std::string name() const
+    {
+        return m_Name;
+    }
+
+    unsigned int max_queue_size() const
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        return m_pHeader->m_MaxQueueSize;
+    }
+
+    unsigned int max_message_size() const
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        return m_pHeader->m_MaxMessageSize;
+    }
+
+    // Mutual exclusion should be guaranteed upon calling this function.
+    void put_message(void const* message_data, unsigned int message_size)
+    {
+        byte* p = reinterpret_cast< byte* >(m_pHeader);
+        p += sizeof(header) + (sizeof(unsigned int) + m_pHeader->m_MaxMessageSize) * m_pHeader->m_PutPos;
+        std::memcpy(p, &message_size, sizeof(unsigned int));
+        p += sizeof(unsigned int);
+        std::memcpy(p, message_data, message_size);
+        m_pHeader->m_PutPos = (m_pHeader->m_PutPos + 1) % m_pHeader->m_MaxQueueSize;
+        ++m_pHeader->m_QueueSize;
+        aux::set_event(m_hNonEmptyQueueEvent);
+    }
+
+    // Mutual exclusion should be guaranteed upon calling this function.
+    void get_message(void* buffer, unsigned int, unsigned int& message_size)
+    {
+        byte* p = reinterpret_cast< byte* >(m_pHeader);
+        p += sizeof(header) + (sizeof(unsigned int) + m_pHeader->m_MaxMessageSize) * m_pHeader->m_GetPos;
+        std::memcpy(&message_size, p, sizeof(unsigned int));
+        p += sizeof(unsigned int);
+        std::memcpy(buffer, p, message_size);
+        m_pHeader->m_GetPos = (m_pHeader->m_GetPos + 1) % m_pHeader->m_MaxQueueSize;
+        --m_pHeader->m_QueueSize;
+        aux::set_event(m_hNonFullQueueEvent);
+    }
+
+    bool send(void const* message_data, unsigned int message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (message_size > m_pHeader->m_MaxMessageSize) throw std::logic_error("Message is too long");
+        errno = 0;
+        mutex_type locker(m_hMutex);
+        
+        while (true)
+        {
+            if (locker.lock() == WAIT_ABANDONED) clear_queue();
+            if (m_pHeader->m_QueueSize >= m_pHeader->m_MaxQueueSize) // full
+            {
+                aux::reset_event(m_hNonFullQueueEvent);
+                locker.unlock();
+                
+                HANDLE handles[2] = { m_hStopEvent, m_hNonFullQueueEvent };
+                DWORD wait_result = aux::wait_for_multiple_objects(2, handles, FALSE, INFINITE);
+                if (wait_result == WAIT_OBJECT_0)
+                {
+                    errno = EINTR;
+                    return false;
+                }
+            }
+            else // not full
+            {
+                put_message(message_data, message_size);
+                return true;
+            }
+        }
+    }
+
+    bool try_send(void const* message_data, unsigned int message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (message_size > m_pHeader->m_MaxMessageSize) throw std::logic_error("Message is too long");
+        mutex_type locker(m_hMutex);
+        if (locker.lock() == WAIT_ABANDONED) clear_queue();
+        if (m_pHeader->m_QueueSize >= m_pHeader->m_MaxQueueSize) return false;
+        put_message(message_data, message_size);
+        return true;
+    }
+
+    bool receive(void* buffer, unsigned int buffer_size, unsigned int& message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (buffer_size < m_pHeader->m_MaxMessageSize) throw std::logic_error("Insufficient buffer");
+        errno = 0;
+        mutex_type locker(m_hMutex);
+        
+        while (true)
+        {
+            if (locker.lock() == WAIT_ABANDONED) clear_queue();
+            if (!m_pHeader->m_QueueSize) // empty
+            {
+                aux::reset_event(m_hNonEmptyQueueEvent);
+                locker.unlock();
+                
+                HANDLE handles[2] = { m_hStopEvent, m_hNonEmptyQueueEvent };
+                DWORD wait_result = aux::wait_for_multiple_objects(2, handles, FALSE, INFINITE);
+                if (wait_result == WAIT_OBJECT_0)
+                {
+                    errno = EINTR;
+                    return false;
+                }
+            }
+            else // nonempty
+            {
+                get_message(buffer, buffer_size, message_size);
+                return true;
+            }
+        }
+    }
+
+    bool try_receive(void* buffer, unsigned int buffer_size, unsigned int& message_size)
+    {
+        if (!is_open()) throw std::logic_error("IPC message queue not opened");
+        if (buffer_size < m_pHeader->m_MaxMessageSize) throw std::logic_error("Insufficient buffer");
+        mutex_type locker(m_hMutex);
+        if (locker.lock() == WAIT_ABANDONED) clear_queue();
+        if (!m_pHeader->m_QueueSize) return false;
+        get_message(buffer, buffer_size, message_size);
+        return true;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//  message_queue_type implementation
+////////////////////////////////////////////////////////////////////////////////
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::message_queue_type()
+  : m_pImpl(new implementation())
+{
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::message_queue_type(
+  char const* name, open_mode mode, unsigned int max_queue_size, unsigned int max_message_size,
+  permission const& permission_value)
+  : m_pImpl(new implementation())
+{
+    open(name, mode, max_queue_size, max_message_size, permission_value);
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::~message_queue_type()
+{
+    delete m_pImpl;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::message_queue_type::message_queue_type(
+  BOOST_RV_REF(message_queue_type) other)
+  : m_pImpl(new implementation())
+{
+    swap(other);
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type&
+basic_text_ipc_message_queue_backend< CharT >::message_queue_type::operator =(
+  BOOST_RV_REF(message_queue_type) other)
+{
+    if (this != &other)
+    {
+        close();
+        swap(other);
+    }
+    return *this;
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::swap(
+  message_queue_type& other)
+{
+    std::swap(m_pImpl, other.m_pImpl);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::open(
+  char const* name, open_mode mode, unsigned int max_queue_size, unsigned int max_message_size,
+  permission const& permission_value)
+{
+    bool ok = false;
+    while (true)
+    {
+        ok = m_pImpl->open(name, mode, max_queue_size, max_message_size, permission_value);
+        if (!ok && mode == open_or_create && errno == ENOENT)
+        {
+            Sleep(0);
+            continue;
+        }
+        break;
+    }
+    return ok;
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::is_open() const
+{
+    return m_pImpl->is_open();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::clear()
+{
+    m_pImpl->clear();
+}
+
+template < typename CharT >
+BOOST_LOG_API std::string basic_text_ipc_message_queue_backend< CharT >::message_queue_type::name() const
+{
+    return m_pImpl->name();
+}
+
+template < typename CharT >
+BOOST_LOG_API unsigned int basic_text_ipc_message_queue_backend< CharT >::message_queue_type::max_queue_size() const
+{
+    return m_pImpl->max_queue_size();
+}
+
+template < typename CharT >
+BOOST_LOG_API unsigned int basic_text_ipc_message_queue_backend< CharT >::message_queue_type::max_message_size() const
+{
+    return m_pImpl->max_message_size();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::stop()
+{
+    m_pImpl->stop();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::reset()
+{
+    m_pImpl->reset();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::message_queue_type::close()
+{
+    if (is_open()) m_pImpl->close();
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::send(
+  void const* message_data, unsigned int message_size)
+{
+    return m_pImpl->send(message_data, message_size);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::try_send(
+  void const* message_data, unsigned int message_size)
+{
+    return m_pImpl->try_send(message_data, message_size);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::receive(
+  void* buffer, unsigned int buffer_size, unsigned int& message_size)
+{
+    return m_pImpl->receive(buffer, buffer_size, message_size);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::message_queue_type::try_receive(
+  void* buffer, unsigned int buffer_size, unsigned int& message_size)
+{
+    return m_pImpl->try_receive(buffer, buffer_size, message_size);
+}
+
+} // namespace sinks
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_WINDOWS
+
+#include <boost/log/detail/footer.hpp>
+
+#endif // BOOST_LOG_IPC_MESSAGE_QUEUE_WIN_HPP_INCLUDED_

--- a/src/posix_wrapper.hpp
+++ b/src/posix_wrapper.hpp
@@ -1,0 +1,248 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   posix_wrapper.hpp
+ * \author Lingxi Li
+ * \date   17.11.2015
+ *
+ * \brief  This header is the Boost.Log library implementation, see the library documentation
+ *         at http://www.boost.org/doc/libs/release/libs/log/doc/html/index.html.
+ *
+ * This file provides checked POSIX.
+ */
+
+#ifndef BOOST_LOG_POSIX_WRAPPER_HPP_INCLUDED_
+#define BOOST_LOG_POSIX_WRAPPER_HPP_INCLUDED_
+
+#include <cerrno>
+#include <cstddef>
+#include <boost/system/system_error.hpp>
+#include <boost/log/detail/config.hpp>
+#include <boost/log/detail/header.hpp>
+
+#ifndef BOOST_WINDOWS
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace aux {
+
+namespace {
+
+inline system::error_code make_error_code(
+  int value = errno,
+  system::error_category const& category = system::system_category())
+{
+    return system::error_code(value, category);
+}
+
+inline system::system_error make_system_error(
+  char const* api_name,
+  int value = errno,
+  system::error_category const& category = system::system_category())
+{
+    return system::system_error(value, category, api_name);
+}
+
+// general file operations
+inline void close(int fd)
+{
+    if (::close(fd) != 0) throw make_system_error("close");
+}
+
+inline void safe_close(int& fd)
+{
+    if (fd >= 0) {
+      close(fd);
+      fd = -1;
+    }
+}
+
+inline void ftruncate(int fd, off_t size)
+{
+    if (::ftruncate(fd, size) != 0) throw make_system_error("ftruncate");
+}
+
+inline void fstat(int fd, struct stat* p_stat)
+{
+    if (::fstat(fd, p_stat) != 0) throw make_system_error("fstat");
+}
+
+// shared memory
+inline int shm_open(char const* name, int oflag, mode_t permission)
+{
+    int shm_fd = ::shm_open(name, oflag, permission);
+    return shm_fd >= 0 ? shm_fd : throw make_system_error("shm_open");
+}
+
+inline void shm_unlink(char const* name)
+{
+    if (::shm_unlink(name) != 0) throw make_system_error("shm_unlink");
+}
+
+inline void* mmap(
+  void* addr, size_t size, int protection, int flag, int fd, off_t offset)
+{
+    void* memory = ::mmap(addr, size, protection, flag, fd, offset);
+    return memory != MAP_FAILED ? memory : throw make_system_error("mmap");
+}
+
+template < typename Ptr >
+inline Ptr typed_mmap(
+  void* addr, size_t size, int protection, int flag, int fd, off_t offset)
+{
+    return static_cast<Ptr>(mmap(addr, size, protection, flag, fd, offset));
+}
+
+inline void munmap(void* memory, size_t size)
+{
+    if (::munmap(memory, size) != 0) throw make_system_error("munmap");
+}
+
+template < typename T >
+inline void safe_munmap(T*& memory, size_t size)
+{
+    if (memory)
+    {
+        munmap(memory, size);
+        memory = NULL;
+    }
+}
+
+// pthread mutex
+inline void pthread_mutexattr_init(pthread_mutexattr_t* p_attr)
+{
+    int err = ::pthread_mutexattr_init(p_attr);
+    if (err != 0) throw make_system_error("pthread_mutexattr_init", err);
+}
+
+inline void pthread_mutexattr_destroy(pthread_mutexattr_t* p_attr)
+{
+    int err = ::pthread_mutexattr_destroy(p_attr);
+    if (err != 0) throw make_system_error("pthread_mutexattr_destroy", err);
+}
+
+inline void pthread_mutexattr_setpshared(pthread_mutexattr_t* p_attr, int val)
+{
+    int err = ::pthread_mutexattr_setpshared(p_attr, val);
+    if (err != 0) throw make_system_error("pthread_mutexattr_setpshared", err);
+}
+
+inline void pthread_mutexattr_setrobust(pthread_mutexattr_t* p_attr, int val)
+{
+    int err = ::pthread_mutexattr_setrobust(p_attr, val);
+    if (err != 0) throw make_system_error("pthread_mutexattr_setrobust", err);
+}
+
+inline void pthread_mutexattr_settype(pthread_mutexattr_t* p_attr, int val)
+{
+    int err = ::pthread_mutexattr_settype(p_attr, val);
+    if (err != 0) throw make_system_error("pthread_mutexattr_settype", err);
+}
+
+inline void pthread_mutex_init(
+  pthread_mutex_t* p_mutex, pthread_mutexattr_t const* p_attr)
+{
+    int err = ::pthread_mutex_init(p_mutex, p_attr);
+    if (err != 0) throw make_system_error("pthread_mutex_init", err);
+}
+
+inline void pthread_mutex_destroy(pthread_mutex_t* p_mutex)
+{
+    int err = ::pthread_mutex_destroy(p_mutex);
+    if (err != 0) throw make_system_error("pthread_mutex_destroy", err);
+}
+
+inline void pthread_mutex_consistent(pthread_mutex_t* p_mutex)
+{
+    int err = ::pthread_mutex_consistent(p_mutex);
+    if (err != 0) throw make_system_error("pthread_mutex_consistent", err);
+}
+
+inline int pthread_mutex_lock(pthread_mutex_t* p_mutex)
+{
+    int err = ::pthread_mutex_lock(p_mutex);
+    return (err == 0 || err == EOWNERDEAD) ? err :
+        throw make_system_error("pthread_mutex_lock", err);
+}
+
+inline void pthread_mutex_unlock(pthread_mutex_t* p_mutex)
+{
+    int err = ::pthread_mutex_unlock(p_mutex);
+    if (err != 0) throw make_system_error("pthread_mutex_unlock", err);
+}
+
+// pthread condition variable
+inline void pthread_condattr_init(pthread_condattr_t* p_attr)
+{
+    int err = ::pthread_condattr_init(p_attr);
+    if (err != 0) throw make_system_error("pthread_condattr_init", err);
+}
+
+inline void pthread_condattr_destroy(pthread_condattr_t* p_attr)
+{
+    int err = ::pthread_condattr_destroy(p_attr);
+    if (err != 0) throw make_system_error("pthread_condattr_destroy", err);
+}
+
+inline void pthread_condattr_setpshared(pthread_condattr_t* p_attr, int val)
+{
+    int err = ::pthread_condattr_setpshared(p_attr, val);
+    if (err != 0) throw make_system_error("pthread_condattr_setpshared", err);
+}
+
+inline void pthread_cond_init(
+  pthread_cond_t* p_cond, pthread_condattr_t const* p_attr)
+{
+    int err = ::pthread_cond_init(p_cond, p_attr);
+    if (err != 0) throw make_system_error("pthread_cond_init", err);
+}
+
+inline void pthread_cond_destroy(pthread_cond_t* p_cond)
+{
+    int err = ::pthread_cond_destroy(p_cond);
+    if (err != 0) throw make_system_error("pthread_cond_destroy", err);
+}
+
+inline int pthread_cond_wait(pthread_cond_t* p_cond, pthread_mutex_t* p_mutex)
+{
+    int err = ::pthread_cond_wait(p_cond, p_mutex);
+    return (err == 0 || err == EOWNERDEAD) ? err :
+        throw make_system_error("pthread_cond_wait", err);
+}
+
+inline void pthread_cond_signal(pthread_cond_t* p_cond)
+{
+    int err = ::pthread_cond_signal(p_cond);
+    if (err != 0) throw make_system_error("pthread_cond_signal", err);
+}
+
+inline void pthread_cond_broadcast(pthread_cond_t* p_cond)
+{
+    int err = ::pthread_cond_broadcast(p_cond);
+    if (err != 0) throw make_system_error("pthread_cond_broadcast", err);
+}
+
+} // unnamed namespace
+
+} // namespace aux
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_WINDOWS
+
+#include <boost/log/detail/footer.hpp>
+
+#endif // BOOST_LOG_POSIX_WRAPPER_HPP_INCLUDED_

--- a/src/text_ipc_message_queue_backend.cpp
+++ b/src/text_ipc_message_queue_backend.cpp
@@ -1,0 +1,233 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   text_ipc_message_queue_backend.cpp
+ * \author Lingxi Li
+ * \date   18.10.2015
+ *
+ * \brief  This header is the Boost.Log library implementation, see the library documentation
+ *         at http://www.boost.org/doc/libs/release/libs/log/doc/html/index.html.
+ */
+
+#include <cerrno>
+#include <cstddef>
+#include <cstring>
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <boost/smart_ptr/scoped_ptr.hpp>
+#include <boost/interprocess/ipc/message_queue.hpp>
+#include <boost/log/sinks/text_ipc_message_queue_backend.hpp>
+#include "ipc_message_queue_posix.hpp"
+#include "ipc_message_queue_win.hpp"
+#include <boost/log/detail/header.hpp>
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace sinks {
+
+////////////////////////////////////////////////////////////////////////////////
+//  Interprocess message queue sink backend implementation
+////////////////////////////////////////////////////////////////////////////////
+//! Sink implementation data
+template < typename CharT >
+struct basic_text_ipc_message_queue_backend< CharT >::implementation
+{
+    message_queue_type  m_MessageQueue;
+    queue_policy_type   m_QueuePolicy;
+    message_policy_type m_MessagePolicy;
+};
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::open_mode const 
+    basic_text_ipc_message_queue_backend< CharT >::create_only;
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::open_mode const
+    basic_text_ipc_message_queue_backend< CharT >::open_only;
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::open_mode const
+    basic_text_ipc_message_queue_backend< CharT >::open_or_create;
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::basic_text_ipc_message_queue_backend()
+{
+    construct(log::aux::empty_arg_list());
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::construct(
+  char const* message_queue_name,
+  open_mode mode,
+  unsigned int max_queue_size,
+  unsigned int max_message_size,
+  queue_policy_type queue_policy_val,
+  message_policy_type message_policy_val,
+  permission const& permission_value)
+{
+    m_pImpl = new implementation();
+    m_pImpl->m_MessageQueue.open(message_queue_name, mode, max_queue_size, 
+        max_message_size, permission_value);
+    m_pImpl->m_QueuePolicy = queue_policy_val;
+    m_pImpl->m_MessagePolicy = message_policy_val;
+}
+
+template < typename CharT >
+BOOST_LOG_API basic_text_ipc_message_queue_backend< CharT >::~basic_text_ipc_message_queue_backend()
+{
+    delete m_pImpl;
+}
+
+template < typename CharT>
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type&
+basic_text_ipc_message_queue_backend< CharT >::message_queue()
+{
+    return m_pImpl->m_MessageQueue;
+}
+
+template < typename CharT>
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_queue_type const&
+basic_text_ipc_message_queue_backend< CharT >::message_queue() const
+{
+    return m_pImpl->m_MessageQueue;
+}
+
+template < typename CharT >
+BOOST_LOG_API std::string basic_text_ipc_message_queue_backend< CharT >::name() const
+{
+    return message_queue().name();
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::open(
+  char const* name, open_mode mode, unsigned int max_queue_size, unsigned int max_message_size,
+  permission const& permission_value)
+{
+    return message_queue().open(name, mode, max_queue_size, max_message_size, permission_value);
+}
+
+template < typename CharT >
+BOOST_LOG_API bool basic_text_ipc_message_queue_backend< CharT >::is_open() const
+{
+    return message_queue().is_open();
+}
+
+template < typename CharT >
+BOOST_LOG_API unsigned int basic_text_ipc_message_queue_backend< CharT >::max_queue_size() const
+{
+    return message_queue().max_queue_size();
+}
+
+template < typename CharT >
+BOOST_LOG_API unsigned int basic_text_ipc_message_queue_backend< CharT >::max_message_size() const
+{
+    return message_queue().max_message_size();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::stop()
+{
+    message_queue().stop();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::reset()
+{
+    message_queue().reset();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::close()
+{
+    message_queue().close();
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::set_queue_policy(queue_policy_type policy)
+{
+    m_pImpl->m_QueuePolicy = policy;
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::set_message_policy(message_policy_type policy)
+{
+    m_pImpl->m_MessagePolicy = policy;
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::queue_policy_type
+basic_text_ipc_message_queue_backend< CharT >::queue_policy() const
+{
+    return m_pImpl->m_QueuePolicy;
+}
+
+template < typename CharT >
+BOOST_LOG_API typename basic_text_ipc_message_queue_backend< CharT >::message_policy_type
+basic_text_ipc_message_queue_backend< CharT >::message_policy() const
+{
+    return m_pImpl->m_MessagePolicy;
+}
+
+template < typename CharT >
+BOOST_LOG_API void basic_text_ipc_message_queue_backend< CharT >::consume(
+  record_view const&, string_type const& message)
+{
+    // No associated message queue, return directly.
+    if (!is_open()) return;
+
+    unsigned int message_size = static_cast< unsigned int >(message.size() * sizeof(char_type));
+    
+    // Deal with messages that are too long.
+    if (message_size > max_message_size())
+    {
+        switch (message_policy())
+        {
+        case drop_when_too_long:
+            return;
+        case truncate_when_too_long:
+            message_size = max_message_size();
+            break;
+        default: // case throw_when_too_long:
+            throw std::logic_error("Message is too long.");
+        }
+    }
+
+    // Send message.
+    if (queue_policy() == block_when_full)
+    {
+        message_queue().send(message.c_str(), message_size);
+    }
+    else
+    {
+        bool succeeded = message_queue().try_send(message.c_str(), message_size);
+        if (queue_policy() == throw_when_full && !succeeded)
+        {
+            throw std::runtime_error("Message queue is full.");
+        }
+    }
+}
+
+//! Explicitly instantiate sink backend implementation
+#ifdef BOOST_LOG_USE_CHAR
+template class basic_text_ipc_message_queue_backend< char >;
+#endif
+#ifdef BOOST_LOG_USE_WCHAR_T
+template class basic_text_ipc_message_queue_backend< wchar_t >;
+#endif
+
+} // namespace sinks
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#include <boost/log/detail/footer.hpp>

--- a/src/win_wrapper.hpp
+++ b/src/win_wrapper.hpp
@@ -1,0 +1,170 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   win_wrapper.hpp
+ * \author Lingxi Li
+ * \date   14.11.2015
+ *
+ * \brief  This header is the Boost.Log library implementation, see the library documentation
+ *         at http://www.boost.org/doc/libs/release/libs/log/doc/html/index.html.
+ *
+ * This file provides checked Windows API.
+ */
+
+#ifndef BOOST_LOG_WIN_WRAPPER_HPP_INCLUDED_
+#define BOOST_LOG_WIN_WRAPPER_HPP_INCLUDED_
+
+#include <boost/system/system_error.hpp>
+#include <boost/log/detail/config.hpp>
+#include <boost/log/detail/header.hpp>
+
+#if defined(BOOST_WINDOWS)
+
+#include <windows.h>
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace aux {
+
+namespace {
+
+inline int get_last_error()
+{
+    return static_cast< int >(GetLastError());
+}
+
+inline system::system_error make_win_system_error(char const* what)
+{
+    return system::system_error(get_last_error(), system::system_category(), what);
+}
+
+inline void close_handle(HANDLE handle)
+{
+    if (!CloseHandle(handle)) throw make_win_system_error("CloseHandle");
+}
+
+inline void safe_close_handle(HANDLE& handle)
+{
+    if (handle)
+    {
+        close_handle(handle);
+        handle = 0;
+    }
+}
+
+inline DWORD wait_for_single_object(HANDLE handle, DWORD duration)
+{
+    DWORD wait_result = WaitForSingleObject(handle, duration);
+    return wait_result != WAIT_FAILED ? wait_result :
+        throw make_win_system_error("WaitForSingleObject");
+}
+
+inline DWORD wait_for_multiple_objects(DWORD num, HANDLE const* handles, BOOL all, DWORD duration)
+{
+    DWORD wait_result = WaitForMultipleObjects(num, handles, all, duration);
+    return wait_result != WAIT_FAILED ? wait_result :
+        throw make_win_system_error("WaitForMultipleObjects");
+}
+
+inline HANDLE create_mutex(SECURITY_ATTRIBUTES* psa, BOOL initial_owner, char const* name)
+{
+    HANDLE hmutex = CreateMutexA(psa, initial_owner, name);
+    return hmutex ? hmutex : throw make_win_system_error("CreateMutex");
+}
+
+inline HANDLE open_mutex(DWORD access, BOOL inheritable, char const* name)
+{
+    HANDLE hmutex = OpenMutexA(access, inheritable, name);
+    return hmutex ? hmutex : throw make_win_system_error("OpenMutex");
+}
+
+inline void release_mutex(HANDLE hmutex)
+{
+    if (!ReleaseMutex(hmutex)) throw make_win_system_error("ReleaseMutex");
+}
+
+inline HANDLE create_event(SECURITY_ATTRIBUTES* psa, BOOL manual, BOOL initial_state, char const* name)
+{
+    HANDLE hevent = CreateEventA(psa, manual, initial_state, name);
+    return hevent ? hevent : throw make_win_system_error("CreateEvent");
+}
+
+inline HANDLE open_event(DWORD access, BOOL inheritable, char const* name)
+{
+    HANDLE hevent = OpenEventA(access, inheritable, name);
+    return hevent ? hevent : throw make_win_system_error("OpenEvent");
+}
+
+inline void set_event(HANDLE hevent)
+{
+    if (!SetEvent(hevent)) throw make_win_system_error("SetEvent");
+}
+
+inline void reset_event(HANDLE hevent)
+{
+    if (!ResetEvent(hevent)) throw make_win_system_error("ResetEvent");
+}
+
+inline HANDLE create_file_mapping(
+  HANDLE hfile,
+  SECURITY_ATTRIBUTES* psa,
+  DWORD protect,
+  DWORD size_high,
+  DWORD size_low,
+  char const* name)
+{
+    HANDLE hfilemapping = CreateFileMappingA(hfile, psa, protect, size_high, size_low, name);
+    return hfilemapping ? hfilemapping : throw make_win_system_error("CreateFileMapping");
+}
+
+inline HANDLE open_file_mapping(DWORD access, BOOL inheritable, char const* name)
+{
+    HANDLE hfilemapping = OpenFileMappingA(access, inheritable, name);
+    return hfilemapping ? hfilemapping : throw make_win_system_error("OpenFileMapping");
+}
+
+inline void* map_view_of_file(
+  HANDLE hfilemapping, 
+  DWORD access, 
+  DWORD offset_high, 
+  DWORD offset_low,
+  SIZE_T size)
+{
+    void* p_memory = MapViewOfFile(hfilemapping, access, offset_high, offset_low, size);
+    return p_memory ? p_memory : throw make_win_system_error("MapViewOfFile");
+}
+
+inline void unmap_view_of_file(void const* p_memory)
+{
+    if (!UnmapViewOfFile(p_memory)) throw make_win_system_error("UnmapViewOfFile");
+}
+
+template < typename T > inline
+void safe_unmap_view_of_file(T*& p)
+{
+    if (p)
+    {
+        unmap_view_of_file(p);
+        p = NULL;
+    }
+}
+
+} // unnamed namespace
+
+} // namespace aux
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_WINDOWS
+
+#include <boost/log/detail/footer.hpp>
+
+#endif // BOOST_LOG_WIN_WRAPPER_HPP_INCLUDED_

--- a/test/run/sink_ipc_backend.cpp
+++ b/test/run/sink_ipc_backend.cpp
@@ -1,0 +1,517 @@
+/*
+ *                 Copyright Lingxi Li 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   sink_ipc_backend.cpp
+ * \author Lingxi Li
+ * \date   19.10.2015
+ *
+ * \brief  The test aims to fully exercise \c text_ipc_message_queue_backend and the
+ *         supporting \c message_queue_type and to ensure that everything works as expected.
+ */
+
+#define BOOST_TEST_MODULE sink_ipc_backend
+
+#include <boost/log/sinks/text_ipc_message_queue_backend.hpp>
+#include <boost/test/unit_test.hpp>
+#include <cerrno>
+#include <cstddef>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <boost/move/utility.hpp>
+
+using namespace boost::log::keywords;
+using namespace boost::log::sinks;
+
+typedef text_ipc_message_queue_backend backend_t;
+typedef backend_t::message_queue_type  queue_t;
+typedef queue_t::permission            permission_t;
+
+namespace boost {
+BOOST_LOG_OPEN_NAMESPACE
+namespace sinks {
+
+//! Permission implementation data
+template < typename CharT >
+struct basic_text_ipc_message_queue_backend< CharT >::message_queue_type::permission::implementation
+{
+#ifdef BOOST_WINDOWS
+    shared_ptr< SECURITY_ATTRIBUTES > m_pSecurityAttr;
+#else
+    mode_t m_Permission;
+#endif
+};
+
+} // namespace sinks
+BOOST_LOG_CLOSE_NAMESPACE
+} // namespace boost
+
+#ifdef BOOST_WINDOWS
+
+SECURITY_ATTRIBUTES* get_native_value(permission_t const& perm)
+{
+    return perm.m_pImpl->m_pSecurityAttr.get();
+}
+
+// The test checks that `permission` works on Windows platforms.
+BOOST_AUTO_TEST_CASE(permission_test)
+{
+    permission_t perm_a;
+    BOOST_TEST(!get_native_value(perm_a));
+    boost::shared_ptr< SECURITY_ATTRIBUTES > ptr(new SECURITY_ATTRIBUTES());
+    permission_t perm_b(ptr);
+    BOOST_TEST(get_native_value(perm_b) == ptr.get());
+    permission_t perm_c(perm_b);
+    BOOST_TEST(get_native_value(perm_c) == ptr.get());
+    permission_t perm_d(boost::move(perm_c));
+    BOOST_TEST(get_native_value(perm_d) == ptr.get());
+    BOOST_TEST(!get_native_value(perm_c));
+    BOOST_TEST(&(perm_c = perm_d) == &perm_c);
+    BOOST_TEST(get_native_value(perm_c) == ptr.get());
+    BOOST_TEST(&(perm_c = perm_c) == &perm_c);
+    BOOST_TEST(get_native_value(perm_c) == ptr.get());
+    BOOST_TEST(&(perm_d = boost::move(perm_c)) == &perm_d);
+    BOOST_TEST(get_native_value(perm_d) == ptr.get());
+    BOOST_TEST(!get_native_value(perm_c));
+    BOOST_TEST(&(perm_d = boost::move(perm_d)) == &perm_d);
+    BOOST_TEST(get_native_value(perm_d) == ptr.get());
+    perm_c.swap(perm_c);
+    BOOST_TEST(!get_native_value(perm_c));
+    swap(perm_c, perm_c);
+    BOOST_TEST(!get_native_value(perm_c));
+    perm_c.swap(perm_d);
+    BOOST_TEST(!get_native_value(perm_d));
+    BOOST_TEST(get_native_value(perm_c) == ptr.get());
+    swap(perm_c, perm_d);
+    BOOST_TEST(get_native_value(perm_d) == ptr.get());
+    BOOST_TEST(!get_native_value(perm_c));
+}
+
+#else // POSIX
+
+mode_t get_native_value(permission_t const& perm)
+{
+    return perm.m_pImpl->m_Permission;
+}
+
+// The test checks that `permission` works on POSIX platforms.
+BOOST_AUTO_TEST_CASE(permission_test)
+{
+    permission_t perm_a;
+    BOOST_TEST(get_native_value(perm_a) == 0644);
+    permission_t perm_b(0666);
+    BOOST_TEST(get_native_value(perm_b) == 0666);
+    permission_t perm_c(perm_b);
+    BOOST_TEST(get_native_value(perm_c) == 0666);
+    permission_t perm_d(boost::move(perm_c));
+    BOOST_TEST(get_native_value(perm_d) == 0666);
+    BOOST_TEST(get_native_value(perm_c) == 0644);
+    BOOST_TEST(&(perm_c = perm_d) == &perm_c);
+    BOOST_TEST(get_native_value(perm_c) == 0666);
+    BOOST_TEST(&(perm_c = perm_c) == &perm_c);
+    BOOST_TEST(get_native_value(perm_c) == 0666);
+    BOOST_TEST(&(perm_d = boost::move(perm_c)) == &perm_d);
+    BOOST_TEST(get_native_value(perm_d) == 0666);
+    BOOST_TEST(get_native_value(perm_c) == 0644);
+    BOOST_TEST(&(perm_d = boost::move(perm_d)) == &perm_d);
+    BOOST_TEST(get_native_value(perm_d) == 0666);
+    perm_c.swap(perm_c);
+    BOOST_TEST(get_native_value(perm_c) == 0644);
+    swap(perm_c, perm_c);
+    BOOST_TEST(get_native_value(perm_c) == 0644);
+    perm_c.swap(perm_d);
+    BOOST_TEST(get_native_value(perm_d) == 0644);
+    BOOST_TEST(get_native_value(perm_c) == 0666);
+    swap(perm_c, perm_d);
+    BOOST_TEST(get_native_value(perm_d) == 0666);
+    BOOST_TEST(get_native_value(perm_c) == 0644);
+}
+
+#endif // BOOST_WINDOWS
+
+// The test checks that `message_queue_type` works.
+BOOST_AUTO_TEST_CASE(message_queue)
+{
+    // Default constructor.
+    {
+        queue_t queue;
+        BOOST_TEST(queue.name().empty());
+        BOOST_TEST(!queue.is_open());
+    }
+    // Open constructor and destructor.
+    {
+        queue_t queue("queue");
+        BOOST_TEST(queue.name() == "queue");
+        BOOST_TEST(queue.is_open());
+        BOOST_TEST(queue.max_queue_size() == 10);
+        BOOST_TEST(queue.max_message_size() == 1000);
+        BOOST_TEST(errno == ENOENT);
+    }
+    // Move constructor.
+    {
+        queue_t queue_a("queue");
+        queue_t queue_b(boost::move(queue_a));
+        BOOST_TEST(queue_a.name().empty());
+        BOOST_TEST(!queue_a.is_open());
+        BOOST_TEST(queue_b.name() == "queue");
+        BOOST_TEST(queue_b.is_open());
+        BOOST_TEST(queue_b.max_queue_size() == 10);
+        BOOST_TEST(queue_b.max_message_size() == 1000);
+    }
+    // Move assignment operator.
+    {
+        queue_t queue_a("queue");
+        BOOST_TEST(&(queue_a = boost::move(queue_a)) == &queue_a);
+        BOOST_TEST(queue_a.name() == "queue");
+        BOOST_TEST(queue_a.is_open());
+        BOOST_TEST(queue_a.max_queue_size() == 10);
+        BOOST_TEST(queue_a.max_message_size() == 1000);
+
+        queue_t queue_b;
+        BOOST_TEST(&(queue_b = boost::move(queue_a)) == &queue_b);
+        BOOST_TEST(queue_b.name() == "queue");
+        BOOST_TEST(queue_b.is_open());
+        BOOST_TEST(queue_b.max_queue_size() == 10);
+        BOOST_TEST(queue_b.max_message_size() == 1000);
+        BOOST_TEST(queue_a.name().empty());
+        BOOST_TEST(!queue_a.is_open());
+    }
+    // Member and non-member swaps.
+    {
+        queue_t queue_a("queue"), queue_b;
+        queue_a.swap(queue_a);
+        BOOST_TEST(queue_a.name() == "queue");
+        BOOST_TEST(queue_a.is_open());
+        BOOST_TEST(queue_a.max_queue_size() == 10);
+        BOOST_TEST(queue_a.max_message_size() == 1000);
+        swap(queue_a, queue_b);
+        BOOST_TEST(queue_a.name().empty());
+        BOOST_TEST(!queue_a.is_open());
+        BOOST_TEST(queue_b.name() == "queue");
+        BOOST_TEST(queue_b.is_open());
+        BOOST_TEST(queue_b.max_queue_size() == 10);
+        BOOST_TEST(queue_b.max_message_size() == 1000);
+    }
+    // open().
+    {
+        // open() performs close() first if a message queue is currently associated.
+        queue_t queue_d("queue");
+        BOOST_TEST(!queue_d.open("queue", queue_d.open_only));
+        BOOST_TEST(queue_d.name().empty());
+        BOOST_TEST(!queue_d.is_open());
+        BOOST_TEST(errno == ENOENT);
+        // Trivial case.
+        queue_t queue("queue");
+        BOOST_TEST(queue.open("queue"));
+        BOOST_TEST(queue.name() == "queue");
+        BOOST_TEST(queue.is_open());
+        BOOST_TEST(queue.max_queue_size() == 10);
+        BOOST_TEST(queue.max_message_size() == 1000);
+        BOOST_TEST(errno == ENOENT);
+        // Close semantics.
+        BOOST_TEST(queue.open(""));
+        BOOST_TEST(queue.name().empty());
+        BOOST_TEST(!queue.is_open());
+        BOOST_TEST(errno == 0);
+        // create_only
+        BOOST_TEST(queue.open("queue", queue.create_only, 1, 2));
+        BOOST_TEST(queue.name() == "queue");
+        BOOST_TEST(queue.is_open());
+        BOOST_TEST(queue.max_queue_size() == 1);
+        BOOST_TEST(queue.max_message_size() == 2);
+        BOOST_TEST(errno == ENOENT);
+        // open_or_create
+        queue_t queue_b;
+        BOOST_TEST(queue_b.open("queue"));
+        BOOST_TEST(queue_b.name() == "queue");
+        BOOST_TEST(queue_b.is_open());
+        BOOST_TEST(queue_b.max_queue_size() == 1);
+        BOOST_TEST(queue_b.max_message_size() == 2);
+        BOOST_TEST(errno == EEXIST);
+        // open_only
+        queue_t queue_c;
+        BOOST_TEST(queue_c.open("queue", queue_c.open_only));
+        BOOST_TEST(queue_c.name() == "queue");
+        BOOST_TEST(queue_c.is_open());
+        BOOST_TEST(queue_c.max_queue_size() == 1);
+        BOOST_TEST(queue_c.max_message_size() == 2);
+        BOOST_TEST(errno == EEXIST);
+        // Failure case.
+        BOOST_TEST(!queue_c.open("x_queue", queue_c.open_only));
+        BOOST_TEST(queue_c.name().empty());
+        BOOST_TEST(!queue_c.is_open());
+        BOOST_TEST(errno == ENOENT);
+    }
+    // is_open(). Done already.
+    // clear()
+    {
+        queue_t queue("queue", queue_t::create_only, 1, 1);
+        BOOST_TEST(queue.is_open());
+        queue_t queue2("queue", queue_t::open_only);
+        BOOST_TEST(queue2.is_open());
+        BOOST_TEST(queue.try_send("x", 1));
+        char c = '\0';
+        unsigned message_size = 0;
+        BOOST_TEST(queue2.try_receive(&c, 1, message_size));
+        BOOST_TEST(c == 'x');
+        BOOST_TEST(queue.try_send("x", 1));
+        queue2.clear();
+        BOOST_TEST(!queue2.try_receive(&c, 1, message_size));
+    }
+    // name(). Done already.
+    // max_queue_size(). Done already.
+    // max_message_size(). Done already.
+    // stop() & reset()
+    {
+        queue_t queue("queue", queue_t::open_or_create, 1, 5);
+        queue.reset();
+        queue.stop();
+        // The object now never blocks.
+        BOOST_TEST(queue.send("msg1", 4));
+        BOOST_TEST(!queue.try_send("msg2", 4));
+        BOOST_TEST(!queue.send("msg2", 4));
+        BOOST_TEST(errno == EINTR);
+        char buffer[5] = {};
+        unsigned int message_size = 0;
+        BOOST_TEST(queue.receive(buffer, 5, message_size));
+        BOOST_TEST(!queue.try_receive(buffer, 5, message_size));
+        BOOST_TEST(!queue.receive(buffer, 5, message_size));
+        BOOST_TEST(errno == EINTR);
+    }
+    // close().
+    {
+        queue_t queue("queue");
+        queue.close();
+        BOOST_TEST(queue.name().empty());
+        BOOST_TEST(!queue.is_open());
+        queue.close();
+        BOOST_TEST(queue.name().empty());
+        BOOST_TEST(!queue.is_open());
+    }
+    // send() and receive().
+    {
+        queue_t queue("queue", queue_t::create_only, 1, 3);
+        BOOST_TEST(errno == ENOENT);
+        BOOST_TEST(queue.send("123", 3));
+        char buffer[4] = {};
+        unsigned int message_size = 0;
+        BOOST_TEST(queue.receive(buffer, 3, message_size));
+        BOOST_TEST(std::strcmp(buffer, "123") == 0);
+        BOOST_TEST(message_size == 3);
+    }
+    // try_send() and try_receive()
+    {
+        queue_t queue("queue", queue_t::create_only, 1, 3);
+        BOOST_TEST(queue.try_send("123", 3));
+        BOOST_TEST(!queue.try_send("456", 3));
+        char buffer[4] = {};
+        unsigned int message_size = 0;
+        BOOST_TEST(queue.try_receive(buffer, 3, message_size));
+        BOOST_TEST(std::strcmp(buffer, "123") == 0);
+        BOOST_TEST(message_size == 3);
+        BOOST_TEST(!queue.try_receive(buffer, 3, message_size));
+    }
+}
+
+// The test checks that `text_ipc_message_queue_backend` works.
+BOOST_AUTO_TEST_CASE(ipc_backend)
+{
+    // Default constructor.
+    {
+        backend_t backend;
+        BOOST_TEST(backend.name().empty());
+        BOOST_TEST(!backend.is_open());
+        BOOST_TEST(backend.queue_policy() == backend.drop_when_full);
+        BOOST_TEST(backend.message_policy() == backend.throw_when_too_long);
+    }
+    // Open constructor and destructor.
+    {
+        backend_t backend(
+            message_queue_name = "queue",
+            open_mode = backend_t::create_only,
+            max_queue_size = 1,
+            max_message_size = 2,
+            queue_policy = backend_t::block_when_full,
+            message_policy = backend_t::truncate_when_too_long,
+            permission = permission_t());
+        BOOST_TEST(errno == ENOENT);
+        BOOST_TEST(backend.name() == "queue");
+        BOOST_TEST(backend.is_open());
+        BOOST_TEST(backend.max_queue_size() == 1);
+        BOOST_TEST(backend.max_message_size() == 2);
+        BOOST_TEST(backend.queue_policy() == backend.block_when_full);
+        BOOST_TEST(backend.message_policy() == backend.truncate_when_too_long);
+    }
+    // message_queue().
+    {
+        backend_t non_const_backend;
+        BOOST_TEST(&non_const_backend.message_queue());
+        backend_t const const_backend;
+        BOOST_TEST(&const_backend.message_queue());
+    }
+    // name(). Done already.
+    // open().
+    {
+        // open() performs close() first if a message queue is currently associated.
+        backend_t queue_d(message_queue_name = "queue");
+        BOOST_TEST(!queue_d.open("queue", queue_d.open_only));
+        BOOST_TEST(queue_d.name().empty());
+        BOOST_TEST(!queue_d.is_open());
+        BOOST_TEST(errno == ENOENT);
+        // Trivial case.
+        // The backend type has a default open mode which is different from that
+        // of the underlying message queue type.
+        backend_t queue(message_queue_name = "queue");
+        BOOST_TEST(!queue.open("queue"));
+        BOOST_TEST(queue.name().empty());
+        BOOST_TEST(!queue.is_open());
+        BOOST_TEST(errno == ENOENT);
+        // Close semantics.
+        BOOST_TEST(queue.open(""));
+        BOOST_TEST(queue.name().empty());
+        BOOST_TEST(!queue.is_open());
+        BOOST_TEST(errno == 0);
+        // create_only
+        BOOST_TEST(queue.open("queue", queue.create_only, 1, 2));
+        BOOST_TEST(queue.name() == "queue");
+        BOOST_TEST(queue.is_open());
+        BOOST_TEST(queue.max_queue_size() == 1);
+        BOOST_TEST(queue.max_message_size() == 2);
+        BOOST_TEST(errno == ENOENT);
+        // open_or_create
+        backend_t queue_b;
+        BOOST_TEST(queue_b.open("queue"));
+        BOOST_TEST(queue_b.name() == "queue");
+        BOOST_TEST(queue_b.is_open());
+        BOOST_TEST(queue_b.max_queue_size() == 1);
+        BOOST_TEST(queue_b.max_message_size() == 2);
+        BOOST_TEST(errno == EEXIST);
+        // open_only
+        backend_t queue_c;
+        BOOST_TEST(queue_c.open("queue", queue_c.open_only));
+        BOOST_TEST(queue_c.name() == "queue");
+        BOOST_TEST(queue_c.is_open());
+        BOOST_TEST(queue_c.max_queue_size() == 1);
+        BOOST_TEST(queue_c.max_message_size() == 2);
+        BOOST_TEST(errno == EEXIST);
+        // Failure case.
+        BOOST_TEST(!queue_c.open("x_queue", queue_c.open_only));
+        BOOST_TEST(queue_c.name().empty());
+        BOOST_TEST(!queue_c.is_open());
+        BOOST_TEST(errno == ENOENT);
+    }
+    // is_open(). Done already.
+    // max_queue_size(). Done already.
+    // max_message_size(). Done already.
+    // stop() and reset().
+    {
+        backend_t queue(
+            message_queue_name = "queue", 
+            open_mode = queue_t::open_or_create,
+            max_queue_size = 1,
+            queue_policy = backend_t::block_when_full);
+        queue.reset();
+        queue.stop();
+        boost::log::record_view rec;
+        // The object now never blocks.
+        queue.consume(rec, "msg1");
+        queue.consume(rec, "msg2");
+        BOOST_TEST(errno == EINTR);
+    }
+    // close().
+    {
+        backend_t backend(
+            message_queue_name = "queue",
+            open_mode = backend_t::open_or_create);
+        backend.close();
+        BOOST_TEST(backend.name().empty());
+        BOOST_TEST(!backend.is_open());
+        backend.close();
+        BOOST_TEST(backend.name().empty());
+        BOOST_TEST(!backend.is_open());
+    }
+    // set_queue_policy().
+    {
+        backend_t backend;
+        backend.set_queue_policy(backend.block_when_full);
+        BOOST_TEST(backend.queue_policy() == backend.block_when_full);
+    }
+    // set_message_policy().
+    {
+        backend_t backend;
+        backend.set_message_policy(backend.truncate_when_too_long);
+        BOOST_TEST(backend.message_policy() == backend.truncate_when_too_long);
+    }
+    // queue_policy(). Done already.
+    // message_policy(). Done already.
+    // consume().
+    {
+        boost::log::record_view rec;
+        backend_t backend;
+        backend.consume(rec, "123");
+        backend.open("queue", backend.create_only, 1, 3);
+        queue_t queue("queue");
+        char buffer[4] = {};
+        // Normal case.
+        backend.consume(rec, "123");
+        unsigned int message_size = 0;
+        queue.try_receive(buffer, 3, message_size);
+        BOOST_TEST(std::strcmp(buffer, "123") == 0);
+        BOOST_TEST(message_size == 3);
+        // Drop when full.
+        backend.consume(rec, "123");
+        backend.consume(rec, "456");
+        queue.try_receive(buffer, 3, message_size);
+        BOOST_TEST(std::strcmp(buffer, "123") == 0);
+        BOOST_TEST(message_size == 3);
+        BOOST_TEST(!queue.try_receive(buffer, 3, message_size));
+        bool thrown = false;
+        // Throw when full.
+        backend.set_queue_policy(backend.throw_when_full);
+        try
+        {
+            backend.consume(rec, "123");
+            backend.consume(rec, "456");
+        }
+        catch (std::runtime_error const& e)
+        {
+            BOOST_TEST(std::strcmp(e.what(), "Message queue is full.") == 0);
+            thrown = true;
+        }
+        BOOST_TEST(thrown);
+        queue.try_receive(buffer, 3, message_size);
+        // Block when full.
+        backend.set_queue_policy(backend.block_when_full);
+        backend.consume(rec, "123");
+        queue.try_receive(buffer, 3, message_size);
+        BOOST_TEST(std::strcmp(buffer, "123") == 0);
+        BOOST_TEST(message_size == 3);
+        // Truncate when too long.
+        backend.set_message_policy(backend.truncate_when_too_long);
+        backend.consume(rec, "12345");
+        queue.try_receive(buffer, 3, message_size);
+        BOOST_TEST(std::strcmp(buffer, "123") == 0);
+        BOOST_TEST(message_size == 3);
+        // Drop when too long.
+        backend.set_message_policy(backend.drop_when_too_long);
+        backend.consume(rec, "12345");
+        BOOST_TEST(!queue.try_receive(buffer, 3, message_size));
+        // Throw when too long.
+        backend.set_message_policy(backend.throw_when_too_long);
+        thrown = false;
+        try
+        {
+            backend.consume(rec, "12345");
+        }
+        catch (std::logic_error const& e)
+        {
+            BOOST_TEST(std::strcmp(e.what(), "Message is too long.") == 0);
+            thrown = true;
+        }
+        BOOST_TEST(thrown);
+    }
+}


### PR DESCRIPTION
It's common to use a viewer process to monitor the interaction of multiple logger processes. I think it may be appropriate for Boost.Log to provide an IPC backend out of the box. Added is a backend that sends formatted log messages to an interprocess message queue created by `boost::interprocess::message_queue`. Users may encode record attributes to the message using JSON and alike. The viewer can then decode the attributes and perform filtering there.
