### PR TITLE
Add catch for stop() method.

### DIFF
--- a/include/boost/log/sinks/async_frontend.hpp
+++ b/include/boost/log/sinks/async_frontend.hpp
@@ -262,7 +262,13 @@ public:
     ~asynchronous_sink()
     {
         boost::this_thread::disable_interruption no_interrupts;
-        stop();
+        try
+        {
+            stop();
+        }
+        catch (...)
+        {
+        }
     }
 
     /*!


### PR DESCRIPTION
stop() method throws as below:
            catch (...)
            {
                m_StopRequested.store(false, boost::memory_order_release);
                throw;
            }
the try-catch block is missing when stop is called.