### PR TITLE
Pass function name as wide-char string on WinCE

### DIFF
--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -29,6 +29,15 @@ BOOST_LOG_OPEN_NAMESPACE
 
 namespace aux {
 
+#if defined(_MSC_VER)
+# if defined(UNDER_CE)
+// On WindowsCE GetProcAddress takes a wide-char string instead
+#   define GET_PROC_ADDRESS_PROC_NAME(t) L##t
+# else
+#   define GET_PROC_ADDRESS_PROC_NAME(t) t
+# endif
+#endif
+
 #if defined(BOOST_LOG_USE_SSSE3)
 extern dump_data_char_t dump_data_char_ssse3;
 extern dump_data_wchar_t dump_data_wchar_ssse3;
@@ -159,11 +168,11 @@ struct function_pointer_initializer
                     mmstate = (eax & 6U) == 6U;
 #elif defined(_MSC_VER)
                     // MSVC does not have an intrinsic for xgetbv, we have to query OS
-                    HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+                    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
                     if (hKernel32)
                     {
                         typedef uint64_t (__stdcall* get_enabled_extended_features_t)(uint64_t);
-                        get_enabled_extended_features_t get_enabled_extended_features = (get_enabled_extended_features_t)GetProcAddress(hKernel32, "GetEnabledExtendedFeatures");
+                        get_enabled_extended_features_t get_enabled_extended_features = (get_enabled_extended_features_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("GetEnabledExtendedFeatures"));
                         if (get_enabled_extended_features)
                         {
                             // XSTATE_MASK_LEGACY_SSE | XSTATE_MASK_GSSE == 6

--- a/src/light_rw_mutex.cpp
+++ b/src/light_rw_mutex.cpp
@@ -32,6 +32,13 @@
 
 #include <boost/log/detail/header.hpp>
 
+#if defined(UNDER_CE)
+// On WindowsCE GetProcAddress takes a wide-char string instead
+#  define GET_PROC_ADDRESS_PROC_NAME(t) L##t
+#else
+#  define GET_PROC_ADDRESS_PROC_NAME(t) t
+#endif
+
 namespace boost {
 
 BOOST_LOG_OPEN_NAMESPACE
@@ -111,27 +118,27 @@ unlock_shared_fun_t g_pUnlockSharedLWRWMutex = NULL;
 //! The function dynamically initializes the implementation pointers
 void init_light_rw_mutex_impl()
 {
-    HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     if (hKernel32)
     {
         g_pInitializeLWRWMutex =
-            (init_fun_t)GetProcAddress(hKernel32, "InitializeSRWLock");
+            (init_fun_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("InitializeSRWLock"));
         if (g_pInitializeLWRWMutex)
         {
             g_pLockExclusiveLWRWMutex =
-                (lock_exclusive_fun_t)GetProcAddress(hKernel32, "AcquireSRWLockExclusive");
+                (lock_exclusive_fun_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("AcquireSRWLockExclusive"));
             if (g_pLockExclusiveLWRWMutex)
             {
                 g_pUnlockExclusiveLWRWMutex =
-                    (unlock_exclusive_fun_t)GetProcAddress(hKernel32, "ReleaseSRWLockExclusive");
+                    (unlock_exclusive_fun_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("ReleaseSRWLockExclusive"));
                 if (g_pUnlockExclusiveLWRWMutex)
                 {
                     g_pLockSharedLWRWMutex =
-                        (lock_shared_fun_t)GetProcAddress(hKernel32, "AcquireSRWLockShared");
+                        (lock_shared_fun_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("AcquireSRWLockShared"));
                     if (g_pLockSharedLWRWMutex)
                     {
                         g_pUnlockSharedLWRWMutex =
-                            (unlock_shared_fun_t)GetProcAddress(hKernel32, "ReleaseSRWLockShared");
+                            (unlock_shared_fun_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("ReleaseSRWLockShared"));
                         if (g_pUnlockSharedLWRWMutex)
                         {
                             g_pDestroyLWRWMutex = &DeinitializeSRWLock;

--- a/src/once_block.cpp
+++ b/src/once_block.cpp
@@ -112,6 +112,13 @@ BOOST_LOG_CLOSE_NAMESPACE // namespace log
 #include <boost/thread/condition_variable.hpp>
 #include <boost/log/detail/header.hpp>
 
+#if defined(UNDER_CE)
+// On WindowsCE GetProcAddress takes a wide-char string instead
+#  define GET_PROC_ADDRESS_PROC_NAME(t) L##t
+#else
+#  define GET_PROC_ADDRESS_PROC_NAME(t) t
+#endif
+
 namespace boost {
 
 BOOST_LOG_OPEN_NAMESPACE
@@ -275,31 +282,31 @@ BOOST_LOG_ANONYMOUS_NAMESPACE {
 
     once_block_impl_base* create_once_block_impl()
     {
-        HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+        HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
         if (hKernel32)
         {
             once_block_impl_nt6::InitializeSRWLock_t pInitializeSRWLock =
-                (once_block_impl_nt6::InitializeSRWLock_t)GetProcAddress(hKernel32, "InitializeSRWLock");
+                (once_block_impl_nt6::InitializeSRWLock_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("InitializeSRWLock"));
             if (pInitializeSRWLock)
             {
                 once_block_impl_nt6::AcquireSRWLockExclusive_t pAcquireSRWLockExclusive =
-                    (once_block_impl_nt6::AcquireSRWLockExclusive_t)GetProcAddress(hKernel32, "AcquireSRWLockExclusive");
+                    (once_block_impl_nt6::AcquireSRWLockExclusive_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("AcquireSRWLockExclusive"));
                 if (pAcquireSRWLockExclusive)
                 {
                     once_block_impl_nt6::ReleaseSRWLockExclusive_t pReleaseSRWLockExclusive =
-                        (once_block_impl_nt6::ReleaseSRWLockExclusive_t)GetProcAddress(hKernel32, "ReleaseSRWLockExclusive");
+                        (once_block_impl_nt6::ReleaseSRWLockExclusive_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("ReleaseSRWLockExclusive"));
                     if (pReleaseSRWLockExclusive)
                     {
                         once_block_impl_nt6::InitializeConditionVariable_t pInitializeConditionVariable =
-                            (once_block_impl_nt6::InitializeConditionVariable_t)GetProcAddress(hKernel32, "InitializeConditionVariable");
+                            (once_block_impl_nt6::InitializeConditionVariable_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("InitializeConditionVariable"));
                         if (pInitializeConditionVariable)
                         {
                             once_block_impl_nt6::SleepConditionVariableSRW_t pSleepConditionVariableSRW =
-                                (once_block_impl_nt6::SleepConditionVariableSRW_t)GetProcAddress(hKernel32, "SleepConditionVariableSRW");
+                                (once_block_impl_nt6::SleepConditionVariableSRW_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("SleepConditionVariableSRW"));
                             if (pSleepConditionVariableSRW)
                             {
                                 once_block_impl_nt6::WakeAllConditionVariable_t pWakeAllConditionVariable =
-                                    (once_block_impl_nt6::WakeAllConditionVariable_t)GetProcAddress(hKernel32, "WakeAllConditionVariable");
+                                    (once_block_impl_nt6::WakeAllConditionVariable_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("WakeAllConditionVariable"));
                                 if (pWakeAllConditionVariable)
                                 {
                                     return new once_block_impl_nt6(

--- a/src/timestamp.cpp
+++ b/src/timestamp.cpp
@@ -49,6 +49,13 @@ BOOST_LOG_API get_tick_count_t get_tick_count = &GetTickCount64;
 
 #else // _WIN32_WINNT >= 0x0600
 
+#if defined(UNDER_CE)
+// On WindowsCE GetProcAddress takes a wide-char string instead
+#  define GET_PROC_ADDRESS_PROC_NAME(t) L##t
+#else
+#  define GET_PROC_ADDRESS_PROC_NAME(t) t
+#endif
+
 BOOST_LOG_ANONYMOUS_NAMESPACE {
 
 #if defined(_MSC_VER) && !defined(_M_CEE_PURE)
@@ -179,10 +186,10 @@ uint64_t __stdcall get_tick_count64()
 
 uint64_t __stdcall get_tick_count_init()
 {
-    HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+    HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     if (hKernel32)
     {
-        get_tick_count_t p = (get_tick_count_t)GetProcAddress(hKernel32, "GetTickCount64");
+        get_tick_count_t p = (get_tick_count_t)GetProcAddress(hKernel32, GET_PROC_ADDRESS_PROC_NAME("GetTickCount64"));
         if (p)
         {
             // Use native API


### PR DESCRIPTION
On Windows CE GetProcAddress takes its parameter as a wide-char string. Unfortunately no such equivalent (e.g. GetProcAddressW) exists on regular Windows. Hence the wrapper macro for its parameter.

A similar problem exists with GetModuleHandleA: it doesn't exist on Windows CE. Luckily a GetModuleHandleW _does_ exist on both the regular Windows and CE.