### PR TITLE
Added max_files option to text_file_backend's file_collector

### DIFF
--- a/example/doc/sinks_xml_file.cpp
+++ b/example/doc/sinks_xml_file.cpp
@@ -33,7 +33,8 @@ void init_file_collecting(boost::shared_ptr< file_sink > sink)
     sink->locked_backend()->set_file_collector(sinks::file::make_collector(
         keywords::target = "logs",                      /*< the target directory >*/
         keywords::max_size = 16 * 1024 * 1024,          /*< maximum total size of the stored files, in bytes >*/
-        keywords::min_free_space = 100 * 1024 * 1024    /*< minimum free space on the drive, in bytes >*/
+        keywords::min_free_space = 100 * 1024 * 1024,   /*< minimum free space on the drive, in bytes >*/
+        keywords::max_files = 512                       /*< maximum number of stored files>*/
     ));
 }
 //]

--- a/example/rotating_file/main.cpp
+++ b/example/rotating_file/main.cpp
@@ -56,7 +56,8 @@ int main(int argc, char* argv[])
         sink->locked_backend()->set_file_collector(sinks::file::make_collector(
             keywords::target = "logs",                          // where to store rotated files
             keywords::max_size = 16 * 1024 * 1024,              // maximum total size of the stored files, in bytes
-            keywords::min_free_space = 100 * 1024 * 1024        // minimum free space on the drive, in bytes
+            keywords::min_free_space = 100 * 1024 * 1024,       // minimum free space on the drive, in bytes
+            keywords::max_files = 512                           // maximum number of stored files
             ));
 
         // Upon restart, scan the target directory for files matching the file_name pattern

--- a/include/boost/log/keywords/max_files.hpp
+++ b/include/boost/log/keywords/max_files.hpp
@@ -1,0 +1,40 @@
+/*
+ *          Copyright Andrey Semashev 2007 - 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   keywords/max_files.hpp
+ * \author Erich Keane
+ * \date   29.12.2015
+ *
+ * The header contains the \c max_files keyword declaration.
+ */
+
+#ifndef BOOST_LOG_KEYWORDS_MAX_FILES_HPP_INCLUDED_
+#define BOOST_LOG_KEYWORDS_MAX_FILES_HPP_INCLUDED_
+
+#include <boost/parameter/keyword.hpp>
+#include <boost/log/detail/config.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+namespace boost {
+
+BOOST_LOG_OPEN_NAMESPACE
+
+namespace keywords {
+
+//! The keyword allows to specify maximum total number of log files
+BOOST_PARAMETER_KEYWORD(tag, max_files)
+
+} // namespace keywords
+
+BOOST_LOG_CLOSE_NAMESPACE // namespace log
+
+} // namespace boost
+
+#endif // BOOST_LOG_KEYWORDS_MAX_FILES_HPP_INCLUDED_

--- a/include/boost/log/sinks/text_file_backend.hpp
+++ b/include/boost/log/sinks/text_file_backend.hpp
@@ -162,6 +162,11 @@ inline shared_ptr< collector > make_collector(T1 const& a1, T2 const& a2, T3 con
 {
     return aux::make_collector((a1, a2, a3));
 }
+template< typename T1, typename T2, typename T3, typename T4 >
+inline shared_ptr< collector > make_collector(T1 const& a1, T2 const& a2, T3 const& a3, T4 const& a4)
+{
+    return aux::make_collector((a1, a2, a3, a4));
+}
 
 #else
 

--- a/include/boost/log/sinks/text_file_backend.hpp
+++ b/include/boost/log/sinks/text_file_backend.hpp
@@ -27,6 +27,7 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/log/keywords/max_size.hpp>
+#include <boost/log/keywords/max_files.hpp>
 #include <boost/log/keywords/min_free_space.hpp>
 #include <boost/log/keywords/target.hpp>
 #include <boost/log/keywords/file_name.hpp>
@@ -129,7 +130,8 @@ namespace aux {
     BOOST_LOG_API shared_ptr< collector > make_collector(
         filesystem::path const& target_dir,
         uintmax_t max_size,
-        uintmax_t min_free_space
+        uintmax_t min_free_space,
+        uintmax_t max_files = (std::numeric_limits< uintmax_t >::max)()
     );
     template< typename ArgsT >
     inline shared_ptr< collector > make_collector(ArgsT const& args)
@@ -137,7 +139,8 @@ namespace aux {
         return aux::make_collector(
             filesystem::path(args[keywords::target]),
             args[keywords::max_size | (std::numeric_limits< uintmax_t >::max)()],
-            args[keywords::min_free_space | static_cast< uintmax_t >(0)]);
+            args[keywords::min_free_space | static_cast< uintmax_t >(0)],
+            args[keywords::max_files | (std::numeric_limits< uintmax_t >::max)()]);
     }
 
 } // namespace aux
@@ -190,6 +193,9 @@ inline shared_ptr< collector > make_collector(T1 const& a1, T2 const& a2, T3 con
  *                         the collector tries to maintain. If the threshold is exceeded, the oldest
  *                         file(s) is deleted to free space. The threshold is not maintained, if not
  *                         specified.
+ * \li \c max_files - Specifies the maximum number of log files stored.  If the number of files exceeds
+ *                    this threshold, the oldest file(s) is deleted to free space.  The threshhold is
+ *                    not maintained if not specified.
  *
  * \return The file collector.
  */

--- a/src/init_from_settings.cpp
+++ b/src/init_from_settings.cpp
@@ -488,10 +488,15 @@ public:
             if (optional< string_type > min_space_param = params["MinFreeSpace"])
                 space = param_cast_to_int< uintmax_t >("MinFreeSpace", min_space_param.get());
 
+            uintmax_t max_files = (std::numeric_limits< uintmax_t >::max)();
+            if (optional< string_type > max_files_param = params["MaxFiles"])
+                max_files = param_cast_to_int< uintmax_t >("MaxFiles", max_files_param.get());
+
             backend->set_file_collector(sinks::file::make_collector(
                 keywords::target = target_dir,
                 keywords::max_size = max_size,
-                keywords::min_free_space = space));
+                keywords::min_free_space = space,
+                keywords::max_files = max_files));
 
             // Scan for log files
             if (optional< string_type > scan_param = params["ScanForFiles"])

--- a/src/parser_utils.hpp
+++ b/src/parser_utils.hpp
@@ -106,6 +106,7 @@ struct char_constants< char >
     static const char_type* target_address_param_name() { return "TargetAddress"; }
     static const char_type* target_param_name() { return "Target"; }
     static const char_type* max_size_param_name() { return "MaxSize"; }
+    static const char_type* max_files_param_name() { return "MaxFiles"; }
     static const char_type* min_free_space_param_name() { return "MinFreeSpace"; }
     static const char_type* scan_for_files_param_name() { return "ScanForFiles"; }
 
@@ -235,6 +236,7 @@ struct char_constants< wchar_t >
     static const char_type* target_address_param_name() { return L"TargetAddress"; }
     static const char_type* target_param_name() { return L"Target"; }
     static const char_type* max_size_param_name() { return L"MaxSize"; }
+    static const char_type* max_files_param_name() { return L"MaxFiles"; }
     static const char_type* min_free_space_param_name() { return L"MinFreeSpace"; }
     static const char_type* scan_for_files_param_name() { return L"ScanForFiles"; }
 


### PR DESCRIPTION
As requested here: https://svn.boost.org/trac/boost/ticket/8746 this commit introduces the boost::log::keywords::max_files keyword and implements this functionality in the file collector.

Additionally, the non-keyword make_collector call has max_files added as a uintmax_t parameter, which has a default value as to not break existing code.

The purpose of this is to limit the total number of files in the collected logs.  If not specified, the limit will be std::numeric_limits<uintmax_t>::max(), which is likely greater than the capacity of the filesystem.
