### PR TITLE
Fix basic_formatting_ostream error on null string

### DIFF
--- a/include/boost/log/utility/formatting_ostream.hpp
+++ b/include/boost/log/utility/formatting_ostream.hpp
@@ -400,7 +400,14 @@ public:
     }
     basic_formatting_ostream& operator<< (const char* p)
     {
-        return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< char >::length(p)));
+        if (p)
+        {
+            return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< char >::length(p)));
+        }
+        else
+        {
+            return *this;
+        }
     }
 
     // When no native character type is supported, the following overloads are disabled as they have ambiguous meaning.
@@ -412,7 +419,14 @@ public:
     }
     basic_formatting_ostream& operator<< (const wchar_t* p)
     {
-        return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< wchar_t >::length(p)));
+        if (p)
+        {
+            return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< wchar_t >::length(p)));
+        }
+        else
+        {
+            return *this;
+        }
     }
 #endif
 #if !defined(BOOST_LOG_NO_CXX11_CODECVT_FACETS)
@@ -423,7 +437,14 @@ public:
     }
     basic_formatting_ostream& operator<< (const char16_t* p)
     {
-        return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< char16_t >::length(p)));
+        if (p)
+        {
+            return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< char16_t >::length(p)));
+        }
+        else
+        {
+            return *this;
+        }
     }
 #endif
 #if !defined(BOOST_NO_CXX11_CHAR32_T)
@@ -433,7 +454,14 @@ public:
     }
     basic_formatting_ostream& operator<< (const char32_t* p)
     {
-        return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< char32_t >::length(p)));
+        if (p)
+        {
+            return this->formatted_write(p, static_cast< std::streamsize >(std::char_traits< char32_t >::length(p)));
+        }
+        else
+        {
+            return *this;
+        }
     }
 #endif
 #endif


### PR DESCRIPTION
See ticket 11956 https://svn.boost.org/trac/boost/ticket/11956

This fix makes the stream work similarly to the std::basic_ostream
version.

Signed-off-by: Erich Keane <erich.keane@intel.com>