### PR TITLE
Request POSIX 2004 definitions on Solaris 10

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -202,7 +202,7 @@ project boost/log
         <target-os>linux:<define>_XOPEN_SOURCE=600
         <target-os>linux:<define>_GNU_SOURCE=1
 
-        <target-os>solaris:<define>_XOPEN_SOURCE=500
+        <target-os>solaris:<define>_XOPEN_SOURCE=600
         <target-os>solaris:<define>__EXTENSIONS__
         <target-os>solaris:<library>socket
         <target-os>solaris:<library>nsl


### PR DESCRIPTION
Otherwise, the Boost Log build fails.

Tested on Solaris 10/SPARC (with gcc 4.9).