### PR TITLE
According to RFC3164, the day of month field in the timestamp should …

### DIFF
--- a/src/syslog_backend.cpp
+++ b/src/syslog_backend.cpp
@@ -377,7 +377,7 @@ BOOST_LOG_ANONYMOUS_NAMESPACE {
         (
             packet,
             sizeof(packet),
-            "<%d>%s % 2d %02d:%02d:%02d %s %s",
+            "<%d>%s %2d %02d:%02d:%02d %s %s",
             pri,
             months[time_stamp->tm_mon],
             time_stamp->tm_mday,


### PR DESCRIPTION
…be formatted as two characters:

    "If the day of the month is less
     than 10, then it MUST be represented as a space and then the
     number.  For example, the 7th day of August would be
     represented as "Aug  7", with two spaces between the "g" and
     the "7".

The printf formatter "%2d" does this. "% 2d" will prepend an unwanted space, e.g.

     printf("Aug % 2d\n", 27) => Aug  27