### PR TITLE
Add dependency on copied images

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -253,6 +253,7 @@ boostbook log
     :
         log_doc
     :
+        <dependency>html/images/log
         <xsl:param>boost.root=../../../..
         <xsl:param>boost.libraries=../../../libs/libraries.htm
         <xsl:param>nav.layout=none


### PR DESCRIPTION
So that it's always copied when the documentation is built.