### PR TITLE
[clang] Fix [-Wc++11-narrowing] error

### DIFF
--- a/include/boost/log/attributes/attribute_name.hpp
+++ b/include/boost/log/attributes/attribute_name.hpp
@@ -53,7 +53,7 @@ public:
     typedef uint32_t id_type;
 
 private:
-    enum { uninitialized = 0xFFFFFFFFu };
+    BOOST_STATIC_CONSTANT(unsigned, uninitialized = 0xFFFFFFFFu);
 
     class repository;
     friend class repository;


### PR DESCRIPTION
boost/log/attributes/attribute_name.hpp:56:28: error: enumerator value evaluates to 4294967295, which cannot be narrowed to type 'int' [-Wc++11-narrowing]
    enum { uninitialized = 0xFFFFFFFFu };
                           ^