### PR TITLE
Add boost-install to build/Jamfile

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -545,3 +545,5 @@ lib boost_log_setup
         <link>shared:<define>BOOST_LOG_SETUP_DYN_LINK=1
         <threading>single:<define>BOOST_LOG_NO_THREADS
     ;
+
+boost-install boost_log boost_log_setup ;


### PR DESCRIPTION
This adds `stage` and `install` targets to the build Jamfile. In addition to being able to issue f.ex. `b2 stage` or `b2 install` from the `build` dir, this also allows enumeration of the library targets from an external Jamfile such as the one in https://github.com/boostorg/check_build/tree/develop/test. Without a stage target to query, the libraries declared with `lib something ;`, being main targets in the build Jamfile, are also picked up, and this is undesirable.

An alternative might be to declare those explicit, but using `boost-install` is good practice anyway.