### PR TITLE
Static destruction bug

### DIFF
--- a/include/boost/log/detail/singleton.hpp
+++ b/include/boost/log/detail/singleton.hpp
@@ -60,8 +60,11 @@ protected:
     //! Returns the singleton instance (not thread-safe)
     static StorageT& get_instance()
     {
-        static StorageT instance;
-        return instance;
+        static StorageT* instance;
+        if (!instance) {
+            instance = new StorageT();
+        }
+        return *instance;
     }
 };
 

--- a/test/run/static_destruction.cpp
+++ b/test/run/static_destruction.cpp
@@ -1,0 +1,34 @@
+#include <boost/log/trivial.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+
+typedef boost::log::trivial::severity_level level;
+typedef boost::log::sources::severity_channel_logger_mt<level> logger;
+
+class LogConstructor {
+ public:
+  LogConstructor() {
+    BOOST_LOG_SEV(log_,  boost::log::trivial::debug) << "LogConstructor class constructed";
+  }
+
+ private:
+  logger log_;
+};
+
+class LogDestructor {
+ public:
+  ~LogDestructor() {
+    BOOST_LOG_SEV(log_,  boost::log::trivial::debug) << "LogDestructor class destructed";
+  }
+
+ private:
+  logger log_;
+};
+
+
+int main(int argc, char* argv[])
+{
+  static LogDestructor d;
+  static LogConstructor c;
+
+  return 0;
+}


### PR DESCRIPTION
This demonstrates an interesting bug that occurs on program exit during static destruction.

statics are destructed in the reverse order in which they are created. In this case, the creation order is `LogDestructor` -> `LogConstructor` -> `lazy_singleton`, so reverse destruction means that when `LogDestructor` attempts to log in its destructor, `lazy_singleton` has already been destroyed.

You can reproduce the crash 100% of the time by running this test case: https://github.com/boostorg/log/commit/907f3e2675afc5abac9d019d2cc42ed7ef926d50

I added an additional commit that is a hacky workaround to make sure the singleton outlives all static variables:  https://github.com/boostorg/log/commit/9455f20d9bb1f9d8fe390f676b734f1c4384ffae. It will probably cause valgrind to complain (haven't tested). If you run with this workaround the test case no longer crashes.