### PR TITLE
Add autolink for Windows

### DIFF
--- a/src/windows/event_log_backend.cpp
+++ b/src/windows/event_log_backend.cpp
@@ -37,6 +37,10 @@
 #include "windows/simple_event_log.h"
 #include <boost/log/detail/header.hpp>
 
+#define BOOST_AUTO_LINK_NOMANGLE
+#define BOOST_LIB_NAME "Psapi"
+#include <boost/config/auto_link.hpp>
+
 namespace boost {
 
 BOOST_LOG_OPEN_NAMESPACE

--- a/src/windows/object_name.cpp
+++ b/src/windows/object_name.cpp
@@ -32,6 +32,10 @@
 #include "windows/utf_code_conversion.hpp"
 #include <boost/log/detail/header.hpp>
 
+#define BOOST_AUTO_LINK_NOMANGLE
+#define BOOST_LIB_NAME "Secur32"
+#include <boost/config/auto_link.hpp>
+
 namespace boost {
 
 BOOST_LOG_OPEN_NAMESPACE


### PR DESCRIPTION
I'm using clang on windows using clang-win toolset.
I have issue when linking the log library:

```
event_log_backend.obj : error LNK2019: unresolved external symbol EnumProcessModules referenced in function "void __cdecl boost::log::v2_mt_nt5::sinks::`anonymous namespace'::init_self_module_handle(struct HINSTANCE__ * &)" (?init_self_module_handle@?A@sinks@v2_mt_nt5@log@boost@@YAXAEAPEAUHINSTANCE__@@@Z)

event_log_backend.obj : error LNK2019: unresolved external symbol GetModuleInformation referenced in function "void __cdecl boost::log::v2_mt_nt5::sinks::`anonymous namespace'::init_self_module_handle(struct HINSTANCE__ * &)" (?init_self_module_handle@?A@sinks@v2_mt_nt5@log@boost@@YAXAEAPEAUHINSTANCE__@@@Z)

object_name.obj : error LNK2019: unresolved external symbol GetUserNameExW referenced in function "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl boost::log::v2_mt_nt5::ipc::`anonymous namespace'::get_scope_prefix(enum log::v2_mt_nt5::ipc::A::object_name::scope)" (?get_scope_prefix@?A@ipc@v2_mt_nt5@log@boost@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4scope@object_name@1234@@Z)
```

I don't know if this is the good way to do that but I solved the issue with this patch