### PR TITLE
Use throw_exception overload taking source_location

### DIFF
--- a/include/boost/log/detail/adaptive_mutex.hpp
+++ b/include/boost/log/detail/adaptive_mutex.hpp
@@ -214,11 +214,7 @@ private:
     template< typename ExceptionT >
     static BOOST_NOINLINE BOOST_LOG_NORETURN void throw_exception(int err, const char* descr, const char* func, const char* file, int line)
     {
-#if !defined(BOOST_EXCEPTION_DISABLE)
-        boost::exception_detail::throw_exception_(ExceptionT(err, descr), func, file, line);
-#else
-        boost::throw_exception(ExceptionT(err, descr));
-#endif
+        boost::throw_exception(ExceptionT(err, descr), boost::source_location(file, line, func));
     }
 };
 

--- a/include/boost/log/detail/adaptive_mutex.hpp
+++ b/include/boost/log/detail/adaptive_mutex.hpp
@@ -26,6 +26,7 @@
 
 #include <boost/throw_exception.hpp>
 #include <boost/thread/exceptions.hpp>
+#include <boost/assert/source_location.hpp>
 
 #if defined(BOOST_THREAD_POSIX) // This one can be defined by users, so it should go first
 #define BOOST_LOG_ADAPTIVE_MUTEX_USE_PTHREAD


### PR DESCRIPTION
`boost::exception_detail::throw_exception_` has been removed.