### PR TITLE
Fix removed typedef in std::allocator in C++20

### DIFF
--- a/include/boost/log/attributes/named_scope.hpp
+++ b/include/boost/log/attributes/named_scope.hpp
@@ -125,10 +125,10 @@ public:
 
     //  Standard types
     typedef allocator_type::value_type value_type;
-    typedef allocator_type::reference reference;
-    typedef allocator_type::const_reference const_reference;
-    typedef allocator_type::pointer pointer;
-    typedef allocator_type::const_pointer const_pointer;
+    typedef allocator_type::value_type& reference;
+    typedef allocator_type::value_type const& const_reference;
+    typedef allocator_type::value_type* pointer;
+    typedef allocator_type::value_type const* const_pointer;
     typedef allocator_type::size_type size_type;
     typedef allocator_type::difference_type difference_type;
 

--- a/src/attribute_set_impl.hpp
+++ b/src/attribute_set_impl.hpp
@@ -65,10 +65,10 @@ public:
     typedef typename base_type::value_type value_type;
     typedef typename base_type::size_type size_type;
     typedef typename base_type::difference_type difference_type;
-    typedef typename base_type::pointer pointer;
-    typedef typename base_type::const_pointer const_pointer;
-    typedef typename base_type::reference reference;
-    typedef typename base_type::const_reference const_reference;
+    typedef typename base_type::value_type* pointer;
+    typedef typename base_type::value_type const* const_pointer;
+    typedef typename base_type::value_type& reference;
+    typedef typename base_type::value_type const& const_reference;
 
 private:
     array< pointer, BOOST_LOG_ATTRIBUTE_SET_MAX_POOL_SIZE > m_Pool;
@@ -122,7 +122,7 @@ public:
             return m_Pool[m_PooledCount];
         }
         else
-            return base_type::allocate(n, hint);
+            return base_type::allocate(n);
     }
 
     void deallocate(pointer p, size_type n)

--- a/src/named_scope.cpp
+++ b/src/named_scope.cpp
@@ -214,7 +214,7 @@ BOOST_LOG_API named_scope_list::named_scope_list(named_scope_list const& that) :
         aux::named_scope_list_node* prev = &m_RootNode;
         for (const_iterator src = that.begin(), end = that.end(); src != end; ++src, ++p)
         {
-            allocator_type::construct(p, *src); // won't throw
+            ::new((void *)p) aux::named_scope_list_node(*src);
             p->_m_pPrev = prev;
             prev->_m_pNext = p;
             prev = p;
@@ -232,7 +232,8 @@ BOOST_LOG_API named_scope_list::~named_scope_list()
         iterator it(m_RootNode._m_pNext);
         iterator end(&m_RootNode);
         while (it != end)
-            allocator_type::destroy(&*(it++));
+            (&*(it++))->~named_scope_list_node();
+            //allocator_type::destroy(&*(it++));
         allocator_type::deallocate(static_cast< pointer >(m_RootNode._m_pNext), m_Size);
     }
 }


### PR DESCRIPTION
In C++ 20, lots of members of std::allocator were removed: https://en.cppreference.com/w/cpp/memory/allocator
```
libs/log/src/attribute_set_impl.hpp:68:41: error: no type named ‘pointer’ in ‘class std::allocator<boost::log::v2_mt_posix::attribute_set::node>’                                                                                                                                           68 |     typedef typename base_type::pointer pointer;                                                                                                                                                                                                                                       |                                         ^~~~~~~
libs/log/src/attribute_set_impl.hpp:69:47: error: no type named ‘const_pointer’ in ‘class std::allocator<boost::log::v2_mt_posix::attribute_set::node>’
   69 |     typedef typename base_type::const_pointer const_pointer;
      |                                               ^~~~~~~~~~~~~
libs/log/src/attribute_set_impl.hpp:70:43: error: no type named ‘reference’ in ‘class std::allocator<boost::log::v2_mt_posix::attribute_set::node>’
   70 |     typedef typename base_type::reference reference;
      |                                           ^~~~~~~~~
libs/log/src/attribute_set_impl.hpp:71:49: error: no type named ‘const_reference’ in ‘class std::allocator<boost::log::v2_mt_posix::attribute_set::node>’
   71 |     typedef typename base_type::const_reference const_reference;
      |                                                 ^~~~~~~~~~~~~~~
```
This PR fixes these compilation issues.