### PR TITLE
Include 'config.hpp' before depending on configuration macros

### DIFF
--- a/src/syslog_backend.cpp
+++ b/src/syslog_backend.cpp
@@ -13,9 +13,9 @@
  *         at http://www.boost.org/doc/libs/release/libs/log/doc/html/index.html.
  */
 
-#ifndef BOOST_LOG_WITHOUT_SYSLOG
-
 #include <boost/log/detail/config.hpp>
+
+#ifndef BOOST_LOG_WITHOUT_SYSLOG
 #include <ctime>
 #include <algorithm>
 #include <stdexcept>


### PR DESCRIPTION
Fixes compilation when a build without support for syslog backends is requested.

Signed-off-by: Daniela Engert <dani@ngrt.de>