### PR TITLE
Work around clang 3.6 compilation error in attachable_sstream_buf.

### DIFF
--- a/include/boost/log/detail/config.hpp
+++ b/include/boost/log/detail/config.hpp
@@ -172,7 +172,7 @@
 #if defined(_MSC_VER)
 #   define BOOST_LOG_ASSUME(expr) __assume(expr)
 #elif defined(__has_builtin)
-#   if __has_builtin(__builtin_assume)
+#   if __has_builtin(__builtin_assume) && (!defined(__clang__) || (__clang_major__ * 100 + __clang_minor__) >= 307)
 #       define BOOST_LOG_ASSUME(expr) __builtin_assume(expr)
 #   else
 #       define BOOST_LOG_ASSUME(expr)


### PR DESCRIPTION
It looks like the compiler has a bug that prevents it from finding
attachable_sstream_buf::append that takes a pointer as the first
argument.

This commit tries to disable __builtin_assume for the compiler. The
builtin was enabled recently and could have triggered the bug.