### PR TITLE
src/event.cpp: fic build on riscv32

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -34,8 +34,12 @@
 // Some Android NDKs (Google NDK and older Crystax.NET NDK versions) don't define SYS_futex
 #if defined(SYS_futex)
 #define BOOST_LOG_SYS_FUTEX SYS_futex
-#else
+#elif defined(__NR_futex)
 #define BOOST_LOG_SYS_FUTEX __NR_futex
+#elif defined(__NR_futex_time64)
+#define BOOST_LOG_SYS_FUTEX __NR_futex_time64
+#else
+#error "Unable to find a suitable futex"
 #endif
 
 #if defined(FUTEX_WAIT_PRIVATE)


### PR DESCRIPTION
riscv32 fails to build because `__NR_futex` is not defined on this architecture:

```
libs/log/src/event.cpp: In member function 'void boost::log::v2_mt_posix::aux::futex_based_event::wait()':
libs/log/src/event.cpp:38:29: error: '__NR_futex' was not declared in this scope
   38 | #define BOOST_LOG_SYS_FUTEX __NR_futex
      |                             ^~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/8c8135fd7c0517c66c9b3975c494da6d7934cc1b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>