### PR TITLE
Don't build `boost_log_setup` library when it isn't necessary. 

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -14,6 +14,7 @@ import feature ;
 import configure ;
 import log-arch-config ;
 import log-platform-config ;
+import log-setup-rules ;
 using mc ;
 
 local here = [ modules.binding $(__name__) ] ;
@@ -391,6 +392,63 @@ rule select-platform-specific-sources ( properties * )
     return $(result) ;
 }
 
+rule select-log-setup-requirements ( properties * )
+{
+    local result ;
+
+    local BOOST_LOG_SETUP_COMMON_SRC =
+        parser_utils.cpp
+        init_from_stream.cpp
+        init_from_settings.cpp
+        settings_parser.cpp
+        filter_parser.cpp
+        formatter_parser.cpp
+        default_filter_factory.cpp
+        matches_relation_factory.cpp
+        default_formatter_factory.cpp
+        ;
+
+    if ! [ has-config-flag BOOST_LOG_WITHOUT_SETTINGS_PARSERS : $(properties) ]
+    {
+        for local srcfile in $(BOOST_LOG_SETUP_COMMON_SRC)
+        {
+            result += <source>setup/$(srcfile) ;
+        }
+        if <link>shared in $(properties)
+        {
+            result += <define>BOOST_LOG_DYN_LINK=1 ;
+            result += <define>BOOST_LOG_SETUP_DLL ;
+        }
+        result += <define>BOOST_LOG_SETUP_BUILDING_THE_LIB=1 ;
+        result += <library>boost_log ;
+    }
+
+    return $(result) ;
+}
+
+rule select-log-setup-usage-requirements ( properties * )
+{
+    local result ;
+
+    if ! [ has-config-flag BOOST_LOG_WITHOUT_SETTINGS_PARSERS : $(properties) ]
+    {
+        if <link>shared in $(properties)
+        {
+            result += <define>BOOST_LOG_SETUP_DYN_LINK=1 ;
+        }
+        if <threading>single in $(properties)
+        {
+            result += <define>BOOST_LOG_NO_THREADS ;
+        }
+    }
+    else
+    {
+        result += <define>BOOST_LOG_SETUP_NO_LIB ;
+    }
+
+    return $(result) ;
+}
+
 lib boost_log
     : ## sources ##
         $(BOOST_LOG_COMMON_SRC)
@@ -405,31 +463,13 @@ lib boost_log
         <threading>single:<define>BOOST_LOG_NO_THREADS
     ;
 
-
-local BOOST_LOG_SETUP_COMMON_SRC =
-    parser_utils.cpp
-    init_from_stream.cpp
-    init_from_settings.cpp
-    settings_parser.cpp
-    filter_parser.cpp
-    formatter_parser.cpp
-    default_filter_factory.cpp
-    matches_relation_factory.cpp
-    default_formatter_factory.cpp
-    ;
-
-lib boost_log_setup
+alias-or-lib boost_log_setup
     : ## sources ##
-        setup/$(BOOST_LOG_SETUP_COMMON_SRC)
     : ## requirements ##
-        <link>shared:<define>BOOST_LOG_DYN_LINK=1
-        <link>shared:<define>BOOST_LOG_SETUP_DLL
-        <define>BOOST_LOG_SETUP_BUILDING_THE_LIB=1
-        <library>boost_log
+        <conditional>@select-log-setup-requirements
     : ## default-build ##
     : ## usage-requirements ##
-        <link>shared:<define>BOOST_LOG_SETUP_DYN_LINK=1
-        <threading>single:<define>BOOST_LOG_NO_THREADS
+        <conditional>@select-log-setup-usage-requirements
     ;
 
 boost-install boost_log boost_log_setup ;

--- a/build/log-setup-rules.jam
+++ b/build/log-setup-rules.jam
@@ -1,0 +1,75 @@
+# log-setup-config.jam
+#
+# Distributed under the Boost Software License Version 1.0. (See
+# accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import "class" : new ;
+import generators ;
+import project ;
+import property-set ;
+import targets ;
+import type ;
+
+type.register ALIAS_OR_LIB ;
+
+# The generator class for alias-or-lib (target type ALIAS_OR_LIB). Depending on properties
+# it will request building of the appropriate type -- ALIAS or LIB
+#
+class alias-or-lib-generator : generator
+{
+    rule __init__ ( * : * )
+    {
+        generator.__init__ $(1) : $(2) : $(3) : $(4) : $(5) : $(6) : $(7) : $(8)
+            : $(9) : $(10) : $(11) : $(12) : $(13) : $(14) : $(15) : $(16) :
+            $(17) : $(18) : $(19) ;
+    }
+
+    rule run ( project name ? : property-set : sources * )
+    {
+        # The alias-or-lib generator is composing, and can be only invoked with
+        # an explicit name. This check is present in generator.run (and so in
+        # builtin.linking-generator) but duplicated here to avoid doing extra
+        # work.
+        if $(name)
+        {
+            local properties = [ $(property-set).raw ] ;
+            # Determine the needed target type.
+            local actual-type ;
+            local flag-to-trigger-alias = BOOST_LOG_WITHOUT_SETTINGS_PARSERS ;
+            if ( "<define>$(flag-to-trigger-alias)" in $(properties) || "<define>$(flag-to-trigger-alias)=1" in $(properties) )
+            {
+                actual-type = ALIAS ;
+            }
+            else
+            {
+                actual-type = LIB ;
+            }
+            # Construct the target.
+            local result = [ generators.construct $(project) $(name) : $(actual-type)
+                : $(property-set) : $(sources) ] ;
+            return $(result) ;
+        }
+    }
+
+    rule viable-source-types ( )
+    {
+        return * ;
+    }
+}
+
+generators.register [ new alias-or-lib-generator alias-or-lib-generator true :  : ALIAS_OR_LIB ] ;
+
+# Declares the 'alias-or-lib' target. It will add an alias-or-lib typed target
+# which will resolve to either an alias or a lib depending on the properties.
+#
+rule alias-or-lib ( name : sources * : requirements * : default-build * :
+    usage-requirements * )
+{
+    local result ;
+
+    result = [ targets.create-typed-target ALIAS_OR_LIB : [ project.current ] : $(name)
+        : $(sources) : $(requirements) : $(default-build) : $(usage-requirements) ] ;
+
+    return $(result) ;
+}


### PR DESCRIPTION
Fixes #164 - this PR uses the presence (or absence) of `BOOST_LOG_WITHOUT_SETTINGS_PARSERS` to switch the `boost_log_setup` target between a an alias or a library.

When that property is defined, the library doesn't actually export any symbols, so it can be replaced by an alias which only defines `BOOST_LOG_SETUP_NO_LIB` to avoid autolinking to a non-existent library.

When `BOOST_LOG_WITHOUT_SETTINGS_PARSERS` is not defined, I believe the behaviour is unchanged. I've only spent a few days with B2, so there may well be better ways to do this, but I couldn't see a way to switch the target type based on properties without using a generator. The generator here is largely inspired by the way the [lib-generator](https://github.com/boostorg/build/blob/develop/src/tools/generators/lib-generator.jam) works. 