### PR TITLE
Stop linking with Boost::regex.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "SunOS")
 endif()
 
 if (BOOST_LOG_USE_REGEX_BACKEND STREQUAL "Boost.Regex")
-    set(boost_log_regex_backend_private_libs Boost::regex)
     list(APPEND boost_log_common_private_defines BOOST_LOG_USE_BOOST_REGEX)
 elseif (BOOST_LOG_USE_REGEX_BACKEND STREQUAL "Boost.Xpressive")
     set(boost_log_regex_backend_private_libs Boost::xpressive)
@@ -530,7 +529,6 @@ target_link_libraries(boost_log_with_support
         Boost::log
 
         Boost::exception
-        Boost::regex
         Boost::spirit
         Boost::xpressive
 )

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -71,23 +71,6 @@ rule check-instruction-set ( properties * )
     return $(result) ;
 }
 
-rule select-regex-backend ( properties * )
-{
-    local result ;
-
-    # Use Boost.Regex backend by default. It produces smaller executables and also has the best performance for small string matching.
-    if ! (
-        [ has-config-flag BOOST_LOG_WITHOUT_SETTINGS_PARSERS : $(properties) ] ||
-        [ has-config-flag BOOST_LOG_WITHOUT_DEFAULT_FACTORIES : $(properties) ] ||
-        [ has-config-flag BOOST_LOG_USE_STD_REGEX : $(properties) ] ||
-        [ has-config-flag BOOST_LOG_USE_BOOST_XPRESSIVE : $(properties) ] )
-    {
-        result = <library>/boost/regex//boost_regex ;
-    }
-
-    return $(result) ;
-}
-
 rule check-pthread-mutex-robust ( properties * )
 {
     local result ;
@@ -163,7 +146,6 @@ project boost/log
     : requirements
         <conditional>@check-instruction-set
         <conditional>@check-atomic-int32
-        <conditional>@select-regex-backend
         <conditional>@check-pthread-mutex-robust
         <conditional>@check-native-syslog
         <conditional>@check-message-compiler


### PR DESCRIPTION
Normally Boost regex is header only when using C++ >= 11, and C++11 become mandatory in Boost::log recently.