### PR TITLE
Fixed compilation error on MinGW-w64.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,10 @@ if (WIN32)
             set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/src/windows/simple_event_log.h" PROPERTIES GENERATED TRUE)
             set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/src/windows/simple_event_log.rc" PROPERTIES GENERATED TRUE)
 
+            if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+                list(APPEND CMAKE_RC_FLAGS "--use-temp-file")
+            endif()
+
             list(APPEND boost_log_sources
                 "${CMAKE_CURRENT_BINARY_DIR}/src/windows/simple_event_log.h"
                 "${CMAKE_CURRENT_BINARY_DIR}/src/windows/simple_event_log.rc"


### PR DESCRIPTION
The default behavior of _windres.exe_ to read the output of the preprocessor is using popen. However, the popen implementation may be buggy on some non-English hosts, which would cause a compilation error like this:

```
windres.exe: can't open file `page:': Invalid argument
```

It can be fixed by adding **--use-temp-file** option and _windres.exe_ will use a temporary file to read instead of using opoen. I also tried compiling with the option on English-only locale and it also works fine, so it is probably a good idea to add it.