### PR TITLE
Make log file counter representation locale-independent

### DIFF
--- a/src/text_file_backend.cpp
+++ b/src/text_file_backend.cpp
@@ -136,6 +136,9 @@ BOOST_LOG_ANONYMOUS_NAMESPACE {
             return (isdigit(c) != 0);
         }
         static std::string default_file_name_pattern() { return "%5N.log"; }
+
+        template< class Int >
+        static std::string to_string(Int num) { return std::to_string(num); }
     };
 
 #ifndef BOOST_LOG_BROKEN_STATIC_CONSTANTS_LINKAGE
@@ -185,6 +188,9 @@ BOOST_LOG_ANONYMOUS_NAMESPACE {
             return (iswdigit(c) != 0);
         }
         static std::wstring default_file_name_pattern() { return L"%5N.log"; }
+
+        template< class Int >
+        static std::wstring to_string(Int num) { return std::to_wstring(num); }
     };
 
 #ifndef BOOST_LOG_BROKEN_STATIC_CONSTANTS_LINKAGE
@@ -263,8 +269,6 @@ BOOST_LOG_ANONYMOUS_NAMESPACE {
         path_string_type::size_type m_FileCounterPosition;
         //! File counter width
         std::streamsize m_Width;
-        //! The file counter formatting stream
-        mutable std::basic_ostringstream< path_char_type > m_Stream;
 
     public:
         //! Initializing constructor
@@ -272,26 +276,26 @@ BOOST_LOG_ANONYMOUS_NAMESPACE {
             m_FileCounterPosition(pos),
             m_Width(width)
         {
-            typedef file_char_traits< path_char_type > traits_t;
-            m_Stream.fill(traits_t::zero);
         }
         //! Copy constructor
         file_counter_formatter(file_counter_formatter const& that) :
             m_FileCounterPosition(that.m_FileCounterPosition),
             m_Width(that.m_Width)
         {
-            m_Stream.fill(that.m_Stream.fill());
         }
 
         //! The function formats the file counter into the file name
         path_string_type operator()(path_string_type const& pattern, unsigned int counter) const
         {
-            path_string_type file_name = pattern;
+            typedef file_char_traits< path_char_type > traits_t;
 
-            m_Stream.str(path_string_type());
-            m_Stream.width(m_Width);
-            m_Stream << counter;
-            file_name.insert(m_FileCounterPosition, m_Stream.str());
+            path_string_type str = traits_t::to_string(counter);
+            // Add padding with zeros
+            if (str.size() < static_cast< size_t >(m_Width))
+                str = path_string_type(m_Width - str.size(), traits_t::zero) + str;
+
+            path_string_type file_name = pattern;
+            file_name.insert(m_FileCounterPosition, str);
 
             return file_name;
         }


### PR DESCRIPTION
In our project using Boost.Log we had an issue with log rotation on Windows that the number and size of log files did not respect the corresponding limits (files were not deleted properly). Upon closer examination the following problem became apparent. The file, say, number 1234 was called something like:
```
20250512-124722.1 234.log
```
Note the space in `1 234`. This happened in locale `std::locale::global(".UTF-8")` on Windows. However, the `scan_for_files()` method that collects old logs, expected the number in "normal" `1234` format. This in turn lead to the fact that Boost.Log did not admit such logs with a space as his own, leaving them on disk forever if the application was restarted and needed to recollect them later with `scan_for_files()`.

Similar problem is reproducible on Linux. For example, I tried to set global locale to `std::locale::global("en_US.UTF-8")`, and the same file becomes called:
```
20250512-124722.1,234.log
```
Again, not a bad name per se, but `scan_for_files()` is unable to parse the comma properly.

This patch fixes the problem by using `std::to_string` and `std::to_wstring` to format numbers, so that the numbers always become contiguous digit sequences digestible by `scan_for_files()`. Alternative solutions considered:

- Fix `scan_for_files()` itself to be able to parse numbers in arbitrary locale. Seems complicated and unneeded.
- Use `.imbue(std::locale("C"))` on the `std::ostream` object that produces the string. This method works, but I was a bit concerned about its portability: is C locale surely present anywhere? It seems like using the functions from C++11 standard is a more surefire solution.