### PR TITLE
complying with BOOST_NO_EXCEPTIONS in log/attributes/value_*.hpp

### DIFF
--- a/include/boost/log/attributes/value_extraction.hpp
+++ b/include/boost/log/attributes/value_extraction.hpp
@@ -238,7 +238,9 @@ public:
         catch (exception& e)
         {
             // Attach the attribute name to the exception
+#ifndef BOOST_NO_EXCEPTIONS
             boost::log::aux::attach_attribute_name_info(e, name);
+#endif
             throw;
         }
     }

--- a/include/boost/log/attributes/value_visitation.hpp
+++ b/include/boost/log/attributes/value_visitation.hpp
@@ -188,7 +188,9 @@ public:
         catch (exception& e)
         {
             // Attach the attribute name to the exception
+#ifndef BOOST_NO_EXCEPTIONS
             boost::log::aux::attach_attribute_name_info(e, name);
+#endif
             throw;
         }
     }


### PR DESCRIPTION
I had difficulty compiling NumCpp (a library depending on boost) in an environment that uses -fno-exceptions

Disabling exception use here with a preprocessor makes it work for me.